### PR TITLE
Refactor page rendering and fix page not properly rendering on opening document

### DIFF
--- a/Caly.Core/Controls/PdfDocumentThumbnailControl.axaml.cs
+++ b/Caly.Core/Controls/PdfDocumentThumbnailControl.axaml.cs
@@ -24,8 +24,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.LogicalTree;
+using Caly.Core.Services;
 using Caly.Core.Utilities;
 using Caly.Core.ViewModels;
+using CommunityToolkit.Mvvm.Messaging;
 
 namespace Caly.Core.Controls
 {
@@ -77,8 +79,8 @@ namespace Caly.Core.Controls
             {
                 return;
             }
-            
-            vm.LoadThumbnail();
+
+            WeakReferenceMessenger.Default.Send(new LoadThumbnailMessage(vm));
         }
 
         private void ListBoxContainerClearing(object? sender, ContainerClearingEventArgs e)
@@ -98,7 +100,7 @@ namespace Caly.Core.Controls
             {
                 // The container is not visible anymore, we unload the thumbnail
                 System.Diagnostics.Debug.WriteLine($"Page {vm.PageNumber} thumbnail out of sight.");
-                vm.UnloadThumbnail();
+                WeakReferenceMessenger.Default.Send(new UnloadThumbnailMessage(vm));
             }
         }
         
@@ -132,7 +134,7 @@ namespace Caly.Core.Controls
                     {
                         if (listBoxItem.DataContext is PdfPageViewModel vm && viewPort.Intersects(listBoxItem.Bounds))
                         {
-                            vm.LoadThumbnail(); // Load image
+                            WeakReferenceMessenger.Default.Send(new LoadThumbnailMessage(vm)); // Load image
                         }
                     }
                 }

--- a/Caly.Core/Controls/PdfPageItem.axaml.cs
+++ b/Caly.Core/Controls/PdfPageItem.axaml.cs
@@ -63,9 +63,7 @@ namespace Caly.Core.Controls
         /// </summary>
         public static readonly DirectProperty<PdfPageItem, PdfPageTextLayerControl?> TextLayerProperty =
             AvaloniaProperty.RegisterDirect<PdfPageItem, PdfPageTextLayerControl?>(nameof(LayoutTransformControl), o => o.TextLayer);
-
-        private PdfPageTextLayerControl? _textLayer;
-
+        
         static PdfPageItem()
         {
             AffectsRender<PdfPageItem>(PictureProperty, IsPageVisibleProperty);
@@ -101,6 +99,8 @@ namespace Caly.Core.Controls
             set => SetValue(ExceptionProperty, value);
         }
 
+        private PdfPageTextLayerControl? _textLayer;
+
         /// <summary>
         /// Gets the text layer.
         /// </summary>
@@ -131,8 +131,6 @@ namespace Caly.Core.Controls
         {
             base.OnDetachedFromLogicalTree(e);
             Picture?.Dispose();
-
-            System.Diagnostics.Debug.Assert((Picture?.RefCount ?? 0) == 0);
         }
     }
 }

--- a/Caly.Core/Models/PdfTextSelection.GetSelection.cs
+++ b/Caly.Core/Models/PdfTextSelection.GetSelection.cs
@@ -87,7 +87,7 @@ namespace Caly.Core.Models
             if (selectedWords is null)
             {
                 // We need to load the layer
-                await page.SetPageTextLayer(token);
+                await page.SetPageTextLayerImmediate(token);
                 selectedWords = GetPageSelectedWords(pageNumber);
 
                 System.Diagnostics.Debug.WriteLine($"GetPageSelectionAsAsync: loaded page interactive layer {pageNumber}.");

--- a/Caly.Core/Services/Interfaces/IPdfService.cs
+++ b/Caly.Core/Services/Interfaces/IPdfService.cs
@@ -30,6 +30,8 @@ namespace Caly.Core.Services.Interfaces
 {
     public interface IPdfService : IAsyncDisposable, IDisposable
     {
+        bool IsActive { get; internal set; }
+
         ITextSelectionHandler? TextSelectionHandler { get; }
         
         int NumberOfPages { get; }
@@ -54,25 +56,24 @@ namespace Caly.Core.Services.Interfaces
 
         Task<IEnumerable<TextSearchResultViewModel>> SearchText(PdfDocumentViewModel pdfDocument, string query, CancellationToken token);
 
-
         Task SetPageSizeAsync(PdfPageViewModel page, CancellationToken token);
 
-        void AskPageSize(PdfPageViewModel page, CancellationToken token);
-        
-        void AskPagePicture(PdfPageViewModel page, CancellationToken token);
+        Task SetPageTextLayerAsync(PdfPageViewModel page, CancellationToken token);
 
-        void AskRemovePagePicture(PdfPageViewModel page);
+        void EnqueueRequestPageSize(PdfPageViewModel page);
         
-        void AskPageThumbnail(PdfPageViewModel page, CancellationToken token);
+        void EnqueueRequestPicture(PdfPageViewModel page);
 
-        void AskRemoveThumbnail(PdfPageViewModel page);
+        void EnqueueRemovePicture(PdfPageViewModel page);
+        
+        void EnqueueRequestThumbnail(PdfPageViewModel page);
+
+        void EnqueueRemoveThumbnail(PdfPageViewModel page);
 
         void ClearAllThumbnail();
         
-        void AskPageTextLayer(PdfPageViewModel page, CancellationToken token);
+        void EnqueueRequestTextLayer(PdfPageViewModel page);
 
-        void AskRemovePageTextLayer(PdfPageViewModel page);
-
-        Task SetPageTextLayer(PdfPageViewModel page, CancellationToken token);
+        void EnqueueRemoveTextLayer(PdfPageViewModel page);
     }
 }

--- a/Caly.Core/Services/LiftiTextSearchService.cs
+++ b/Caly.Core/Services/LiftiTextSearchService.cs
@@ -67,7 +67,7 @@ namespace Caly.Core.Services
                                 var textLayer = p.PdfTextLayer;
                                 if (textLayer is null)
                                 {
-                                    await p.SetPageTextLayer(ct);
+                                    await p.SetPageTextLayerImmediate(ct);
                                     textLayer = p.PdfTextLayer;
                                 }
 
@@ -87,7 +87,7 @@ namespace Caly.Core.Services
                                 var textLayer = p.PdfTextLayer;
                                 if (textLayer is null)
                                 {
-                                    await p.SetPageTextLayer(ct);
+                                    await p.SetPageTextLayerImmediate(ct);
                                     textLayer = p.PdfTextLayer;
                                 }
 

--- a/Caly.Core/Services/Messages.cs
+++ b/Caly.Core/Services/Messages.cs
@@ -1,0 +1,12 @@
+﻿using Caly.Core.ViewModels;
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Caly.Core.Services
+{
+    internal sealed class LoadPageMessage(PdfPageViewModel value) : ValueChangedMessage<PdfPageViewModel>(value);
+    internal sealed class LoadPageSizeMessage(PdfPageViewModel value) : ValueChangedMessage<PdfPageViewModel>(value);
+    internal sealed class LoadThumbnailMessage(PdfPageViewModel value) : ValueChangedMessage<PdfPageViewModel>(value);
+    internal sealed class SelectedDocumentChangedMessage(PdfDocumentViewModel value) : ValueChangedMessage<PdfDocumentViewModel>(value);
+    internal sealed class UnloadPageMessage(PdfPageViewModel value) : ValueChangedMessage<PdfPageViewModel>(value);
+    internal sealed class UnloadThumbnailMessage(PdfPageViewModel value) : ValueChangedMessage<PdfPageViewModel>(value);
+}

--- a/Caly.Core/Services/PdfPigPdfService.Lock.cs
+++ b/Caly.Core/Services/PdfPigPdfService.Lock.cs
@@ -60,6 +60,5 @@ namespace Caly.Core.Services
                 }
             }
         }
-
     }
 }

--- a/Caly.Core/Services/PdfPigPdfService.RenderQueue.cs
+++ b/Caly.Core/Services/PdfPigPdfService.RenderQueue.cs
@@ -1,0 +1,182 @@
+﻿using Caly.Core.ViewModels;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Caly.Core.Services
+{
+    internal partial class PdfPigPdfService
+    {
+        private readonly ConcurrentDictionary<int, CancellationTokenSource> _pictureTokens = new();
+        private readonly ConcurrentDictionary<int, CancellationTokenSource> _textLayerTokens = new();
+        private readonly ConcurrentDictionary<int, CancellationTokenSource> _thumbnailTokens = new();
+
+        #region Picture
+
+        public void EnqueueRequestPageSize(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestPageSize {page.PageNumber}");
+
+            if (IsDisposed())
+            {
+                return;
+            }
+
+            if (!IsActive)
+            {
+                System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestPageSize {page.PageNumber}: Skipping as not active");
+                return;
+            }
+
+            // No cancel possible
+            if (!_requestsWriter.TryWrite(new RenderRequest(page, RenderRequestTypes.PageSize, CancellationToken.None)))
+            {
+                throw new Exception("Could not write request to channel."); // Should never happen as unbounded channel
+            }
+        }
+
+        public void EnqueueRequestPicture(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestPicture {page.PageNumber}");
+
+            if (IsDisposed())
+            {
+                return;
+            }
+
+            if (!IsActive)
+            {
+                System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestPicture {page.PageNumber}: Skipping as not active");
+                return;
+            }
+
+            var pageCts = CancellationTokenSource.CreateLinkedTokenSource(_mainCts.Token);
+
+            if (_pictureTokens.TryAdd(page.PageNumber, pageCts))
+            {
+                if (!_requestsWriter.TryWrite(new RenderRequest(page, RenderRequestTypes.Picture, pageCts.Token)))
+                {
+                    throw new Exception("Could not write request to channel."); // Should never happen as unbounded channel
+                }
+            }
+        }
+
+        public void EnqueueRemovePicture(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRemovePicture {page.PageNumber}");
+
+            var picture = page.PdfPicture;
+
+            page.PdfPicture = null;
+            if (_pictureTokens.TryRemove(page.PageNumber, out var cts))
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+
+            picture?.Dispose();
+
+            //System.Diagnostics.Debug.Assert((picture?.RefCount ?? 0) == 0);
+        }
+
+        #endregion
+
+        #region Text layer
+
+        public void EnqueueRequestTextLayer(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestTextLayer {page.PageNumber}");
+
+            if (IsDisposed())
+            {
+                return;
+            }
+
+            if (!IsActive)
+            {
+                System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestTextLayer {page.PageNumber}: Skipping as not active");
+                return;
+            }
+
+            var pageCts = CancellationTokenSource.CreateLinkedTokenSource(_mainCts.Token);
+
+            if (_textLayerTokens.TryAdd(page.PageNumber, pageCts))
+            {
+                if (!_requestsWriter.TryWrite(new RenderRequest(page, RenderRequestTypes.TextLayer, pageCts.Token)))
+                {
+                    throw new Exception("Could not write request to channel."); // Should never happen as unbounded channel
+                }
+            }
+        }
+
+        public void EnqueueRemoveTextLayer(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRemoveTextLayer {page.PageNumber}");
+
+            if (_textLayerTokens.TryRemove(page.PageNumber, out var cts))
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+        }
+
+        #endregion
+
+        #region Thumbnail
+
+        public void EnqueueRequestThumbnail(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestThumbnail {page.PageNumber}");
+
+            if (IsDisposed())
+            {
+                return;
+            }
+
+            if (!IsActive)
+            {
+                System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRequestThumbnail {page.PageNumber}: Skipping as not active");
+                return;
+            }
+
+            var pageCts = CancellationTokenSource.CreateLinkedTokenSource(_mainCts.Token);
+
+            if (_thumbnailTokens.TryAdd(page.PageNumber, pageCts))
+            {
+                if (!_requestsWriter.TryWrite(new RenderRequest(page, RenderRequestTypes.Thumbnail, pageCts.Token)))
+                {
+                    throw new Exception("Could not write request to channel."); // Should never happen as unbounded channel
+                }
+            }
+
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] Thumbnail Count {_bitmaps.Count}");
+        }
+
+        public void EnqueueRemoveThumbnail(PdfPageViewModel page)
+        {
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] EnqueueRemoveThumbnail {page.PageNumber}");
+
+            var thumbnail = page.Thumbnail;
+            page.Thumbnail = null;
+
+            if (_thumbnailTokens.TryRemove(page.PageNumber, out var cts))
+            {
+                System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] REMOVED {page.PageNumber}");
+                cts.Cancel();
+                cts.Dispose();
+            }
+
+            if (_bitmaps.TryRemove(page.PageNumber, out var vm))
+            {
+                // Should always be null
+                //System.Diagnostics.Debug.Assert(vm.Thumbnail is null);
+            }
+
+            thumbnail?.Dispose();
+
+            System.Diagnostics.Debug.WriteLine($"[{GetLogFileName()}] [RENDER] Thumbnail Count {_bitmaps.Count}");
+        }
+
+        #endregion
+    }
+}

--- a/Caly.Core/ViewModels/MainViewModel.cs
+++ b/Caly.Core/ViewModels/MainViewModel.cs
@@ -18,6 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using Avalonia.Collections;
+using Caly.Core.Services.Interfaces;
+using Caly.Core.Utilities;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -26,12 +33,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Collections;
-using Caly.Core.Services.Interfaces;
-using Caly.Core.Utilities;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using Microsoft.Extensions.DependencyInjection;
+using Caly.Core.Services;
 using Tabalonia.Controls;
 
 namespace Caly.Core.ViewModels
@@ -48,12 +50,17 @@ namespace Caly.Core.ViewModels
 
         [ObservableProperty] private string _version = CalyExtensions.GetCalyVersion();
 
-#if DEBUG
         partial void OnSelectedDocumentIndexChanged(int oldValue, int newValue)
         {
             System.Diagnostics.Debug.WriteLine($"Selected Document Index changed from {oldValue} to {newValue}.");
+            var currentDoc = GetCurrentPdfDocument();
+            if (currentDoc is null)
+            {
+                return;
+            }
+            
+            WeakReferenceMessenger.Default.Send(new SelectedDocumentChangedMessage(currentDoc));
         }
-#endif
 
         public MainViewModel()
         {


### PR DESCRIPTION
- Use `CommunityToolkit.Mvvm.Messaging` messaging to simplify render request process
- Centralise render request queuing in `PdfDocumentsService` and simplify `PdfPageViewModel`
- Check if the document is active before enqueuing requests
- Fix bug in `PdfPageItemsControl.ClearContainerForItemOverride(...)` causing pages to not load properly when opening a new document
- Use `lock` in `SkiaPdfPageControl`
- Improve logs