### PR TITLE
Misc Task bug fixes and improvements

### DIFF
--- a/Caly.Core/Services/JsonSettingsService.cs
+++ b/Caly.Core/Services/JsonSettingsService.cs
@@ -340,14 +340,16 @@ internal sealed class JsonSettingsService : ISettingsService
 
                 await using (FileStream createStream = File.Create(SettingsFileFullPath))
                 {
-                    await JsonSerializer.SerializeAsync(createStream, _current, SourceGenerationContext.Default.CalySettings);
+                    await JsonSerializer.SerializeAsync(createStream, _current, SourceGenerationContext.Default.CalySettings)
+                        .ConfigureAwait(false);
                 }
                 return;
             }
 
             await using (FileStream createStream = File.OpenRead(SettingsFileFullPath))
             {
-                _current = await JsonSerializer.DeserializeAsync(createStream, SourceGenerationContext.Default.CalySettings);
+                _current = await JsonSerializer.DeserializeAsync(createStream, SourceGenerationContext.Default.CalySettings)
+                    .ConfigureAwait(false);
                 ValidateSetting(_current);
             }
         }
@@ -405,7 +407,8 @@ internal sealed class JsonSettingsService : ISettingsService
             {
                 await using (FileStream createStream = File.Create(SettingsFileFullPath))
                 {
-                    await JsonSerializer.SerializeAsync(createStream, _current, SourceGenerationContext.Default.CalySettings);
+                    await JsonSerializer.SerializeAsync(createStream, _current, SourceGenerationContext.Default.CalySettings)
+                        .ConfigureAwait(false);
                 }
             }
             catch (JsonException jsonEx)

--- a/Caly.Core/Services/PdfDocumentsManagerService.cs
+++ b/Caly.Core/Services/PdfDocumentsManagerService.cs
@@ -52,6 +52,7 @@ internal sealed partial class PdfDocumentsManagerService : IPdfDocumentsManagerS
 
     private readonly ChannelWriter<IStorageFile?> _channelWriter;
     private readonly ChannelReader<IStorageFile?> _channelReader;
+    private readonly CancellationTokenSource _processingQueueCts = new();
 
     private readonly ConcurrentDictionary<string, PdfDocumentRecord> _openedFiles = new();
 
@@ -113,7 +114,7 @@ internal sealed partial class PdfDocumentsManagerService : IPdfDocumentsManagerS
 
         RegisterMessagesHandlers();
 
-        _ = Task.Run(() => ProcessDocumentsQueue(CancellationToken.None));
+        _ = Task.Run(() => ProcessDocumentsQueue(_processingQueueCts.Token));
     }
 
     public async Task OpenLoadDocument(CancellationToken cancellationToken)
@@ -281,7 +282,7 @@ internal sealed partial class PdfDocumentsManagerService : IPdfDocumentsManagerS
             }
 
             // TODO - Log error
-            await Task.Run(scope.DisposeAsync, CancellationToken.None);
+            await scope.DisposeAsync();
         }
     }
 
@@ -293,7 +294,8 @@ internal sealed partial class PdfDocumentsManagerService : IPdfDocumentsManagerS
 
     public void Dispose()
     {
-        // https://formatexception.com/2024/03/using-messenger-in-the-communitytoolkit-mvvm/
+        _processingQueueCts.Cancel();
+        _processingQueueCts.Dispose();
         App.Messenger.UnregisterAll(this);
     }
 }

--- a/Caly.Core/Services/PdfPigDocumentService.Lock.cs
+++ b/Caly.Core/Services/PdfPigDocumentService.Lock.cs
@@ -45,7 +45,7 @@ internal partial class PdfPigDocumentService
         bool hasLock = false;
         try
         {
-            await _semaphore.WaitAsync(token);
+            await _semaphore.WaitAsync(token).ConfigureAwait(false);
             hasLock = true;
 
             if (IsDisposed())
@@ -78,7 +78,7 @@ internal partial class PdfPigDocumentService
             using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, _mainCts.Token))
             {
                 linkedCts.Token.ThrowIfCancellationRequested();
-                await action(linkedCts.Token);
+                await action(linkedCts.Token).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
@@ -102,7 +102,7 @@ internal partial class PdfPigDocumentService
             using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, _mainCts.Token))
             {
                 linkedCts.Token.ThrowIfCancellationRequested();
-                return await action(linkedCts.Token);
+                return await action(linkedCts.Token).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)

--- a/Caly.Core/Services/PdfPigDocumentService.cs
+++ b/Caly.Core/Services/PdfPigDocumentService.cs
@@ -108,13 +108,14 @@ internal sealed partial class PdfPigDocumentService : IPdfDocumentService
                 _filePath = _storageFile.Path;
                 System.Diagnostics.Debug.WriteLine($"[INFO] Opening {FileName}...");
 
-                _fileStream = await _storageFile.OpenReadAsync();
+                _fileStream = await _storageFile.OpenReadAsync().ConfigureAwait(false);
+
                 if (!_fileStream.CanSeek)
                 {
                     var ms = new MemoryStream((int)_fileStream.Length);
-                    await _fileStream.CopyToAsync(ms, ct);
+                    await _fileStream.CopyToAsync(ms, ct).ConfigureAwait(false);
                     ms.Position = 0;
-                    await _fileStream.DisposeAsync();
+                    await _fileStream.DisposeAsync().ConfigureAwait(false);
                     _fileStream = ms;
                 }
 
@@ -171,7 +172,7 @@ internal sealed partial class PdfPigDocumentService : IPdfDocumentService
                         continue;
                     }
 
-                    var pageCount = await OpenDocument(_storageFile, pw, ct);
+                    var pageCount = await OpenDocument(_storageFile, pw, ct).ConfigureAwait(false);
                     if (pageCount > 0)
                     {
                         // Password OK and document opened

--- a/Caly.Core/ViewModels/DocumentViewModel.TextSearch.cs
+++ b/Caly.Core/ViewModels/DocumentViewModel.TextSearch.cs
@@ -56,16 +56,9 @@ public partial class DocumentViewModel
 
     [ObservableProperty] private TextSearchResult? _selectedTextSearchResult;
 
-    async partial void OnTextSearchChanged(string? value)
+    partial void OnTextSearchChanged(string? value)
     {
-        try
-        {
-            await SearchText(); // TODO - subscribe to event change instead and use rolling time window
-        }
-        catch (Exception e)
-        {
-            Debug.WriteExceptionToFile(e);
-        }
+        SearchTextCommand.Execute(null);
     }
 
     [RelayCommand]

--- a/Caly.Core/ViewModels/DocumentViewModel.cs
+++ b/Caly.Core/ViewModels/DocumentViewModel.cs
@@ -32,6 +32,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -320,31 +321,40 @@ public sealed partial class DocumentViewModel : ViewModelBase
         ArgumentNullException.ThrowIfNull(storageFile, nameof(storageFile));
         LocalPath = storageFile.Path.LocalPath;
 
-        WaitOpenAsync = Task.Run(async () =>
-        {
-            using (var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(_mainCts.Token, token))
-            {
-                int pageCount = await _pdfService.OpenDocument(storageFile, password, combinedCts.Token);
-
-                IsPasswordProtected = _pdfService.IsPasswordProtected;
-                FileName = _pdfService.FileName;
-                System.Diagnostics.Debug.Assert(_pdfService.LocalPath == LocalPath);
-
-                if (pageCount == 0)
-                {
-                    return pageCount;
-                }
-
-                PageCount = _pdfService.NumberOfPages;
-                TextSelection = new TextSelection(PageCount);
-
-                _pdfPageService.Initialise();
-
-                return pageCount;
-            }
-        }, token);
-
+        WaitOpenAsync = OpenDocumentCore(storageFile, password, token);
         return WaitOpenAsync;
+    }
+
+    private async Task<int> OpenDocumentCore(IStorageFile? storageFile, string? password, CancellationToken token)
+    {
+        using var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(_mainCts.Token, token);
+
+        int pageCount = await _pdfService.OpenDocument(storageFile, password, combinedCts.Token).ConfigureAwait(false);
+
+        System.Diagnostics.Debug.Assert(_pdfService.LocalPath == LocalPath);
+
+        bool isPasswordProtected = _pdfService.IsPasswordProtected;
+        string? fileName = _pdfService.FileName;
+        int numberOfPages = _pdfService.NumberOfPages;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            IsPasswordProtected = isPasswordProtected;
+            FileName = fileName;
+
+            if (pageCount > 0)
+            {
+                PageCount = numberOfPages;
+                TextSelection = new TextSelection(numberOfPages);
+            }
+        });
+
+        if (pageCount > 0)
+        {
+            _pdfPageService.Initialise();
+        }
+
+        return pageCount;
     }
 
     internal async ValueTask CancelAsync()
@@ -354,8 +364,10 @@ public sealed partial class DocumentViewModel : ViewModelBase
 
     private async Task LoadPages()
     {
+        Debug.ThrowOnUiThread();
+
         System.Diagnostics.Debug.Assert(TextSelection is not null);
-        
+
         if (PageCount == 0)
         {
             if (IsPasswordProtected)
@@ -365,37 +377,42 @@ public sealed partial class DocumentViewModel : ViewModelBase
             throw new Exception("Cannot load pages because document has 0 pages.");
         }
 
-        await Task.Run(async () =>
+        // Use 1st page size as default page size
+        var firstPage = new PageViewModel(1, TextSelection);
+        var pageInfo = await _pdfPageService.GetPageSize(1, _mainCts.Token).ConfigureAwait(false);
+        if (pageInfo.HasValue)
         {
-            // Use 1st page size as default page size
-            var firstPage = new PageViewModel(1, TextSelection);
-            var pageInfo = await _pdfPageService.GetPageSize(1, _mainCts.Token);
-            if (pageInfo.HasValue)
+            // Page is not yet in the collection — no UI observer yet, safe to call from thread pool
+            firstPage.SetSize(pageInfo.Value.Width, pageInfo.Value.Height, _pdfService.PpiScale);
+        }
+
+        double defaultWidth = firstPage.Width * _pdfService.PpiScale;
+        double defaultHeight = firstPage.Height * _pdfService.PpiScale;
+
+        // Build all page view models on the thread pool
+        var allPages = new PageViewModel[PageCount];
+        allPages[0] = firstPage;
+
+        for (int p = 2; p <= PageCount; ++p)
+        {
+            _mainCts.Token.ThrowIfCancellationRequested();
+            var newPage = new PageViewModel(p, TextSelection)
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    firstPage.SetSize(pageInfo.Value.Width, pageInfo.Value.Height,
-                        _pdfService.PpiScale);
-                });
-            }
+                Height = defaultHeight,
+                Width = defaultWidth
+            };
+            _pdfPageService.RequestPageSize(newPage);
+            allPages[p - 1] = newPage;
+        }
 
-            double defaultWidth = firstPage.Width * _pdfService.PpiScale;
-            double defaultHeight = firstPage.Height * _pdfService.PpiScale;
-
-            Pages.Add(firstPage);
-
-            for (int p = 2; p <= PageCount; ++p)
+        // Add all pages to the UI-bound collection in a single UI-thread dispatch
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            foreach (var page in allPages)
             {
-                _mainCts.Token.ThrowIfCancellationRequested();
-                var newPage = new PageViewModel(p, TextSelection)
-                {
-                    Height = defaultHeight,
-                    Width = defaultWidth
-                };
-                _pdfPageService.RequestPageSize(newPage);
-                Pages.Add(newPage);
+                Pages.Add(page);
             }
-        }, _mainCts.Token);
+        });
     }
 
     [RelayCommand(CanExecute = nameof(CanGoToPreviousPage))]
@@ -509,15 +526,28 @@ public sealed partial class DocumentViewModel : ViewModelBase
     [RelayCommand]
     private async Task Clear()
     {
-        await Task.Run(() =>
+        // Capture pictures/thumbnails and clear all UI-bound page properties on the UI thread
+        // in one batch, then dispose the captured resources off the UI thread.
+        var toDispose = new List<IDisposable?>();
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
         {
             foreach (var page in Pages)
             {
-                page.Clear();
+                toDispose.Add(page.PdfPicture);
+                toDispose.Add(page.Thumbnail);
+                page.PdfTextLayer = null;
+                page.PdfPicture = null;
+                page.Thumbnail = null;
             }
         });
 
-        await _pdfPageService.CancelAndClear();
+        foreach (var item in toDispose)
+        {
+            item?.Dispose();
+        }
+
+        await _pdfPageService.CancelAndClear().ConfigureAwait(false);
 
         GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, false);
     }


### PR DESCRIPTION
PdfDocumentsManagerService.cs
  - Added _processingQueueCts to give the background queue loop a proper lifecycle (cancel on Dispose())
  - Fixed bug: await Task.Run(scope.DisposeAsync, CancellationToken.None) → await scope.DisposeAsync() (the ValueTask was silently discarded via the Action overload)

PdfPigDocumentService.cs
  - Added .ConfigureAwait(false) to OpenReadAsync(), CopyToAsync(), DisposeAsync(), and the recursive OpenDocument() call

PdfPigDocumentService.Lock.cs
  - Added .ConfigureAwait(false) to _semaphore.WaitAsync() and both await action(...) calls

JsonSettingsService.cs
  - Added .ConfigureAwait(false) to all three JsonSerializer.SerializeAsync/DeserializeAsync calls

PdfPageService.cs
  - Added .ConfigureAwait(false) to all real Task-returning awaits (GetPageSize, GetPicture, GetTextLayer, SetThumbnail)

DocumentViewModel.cs
  - Refactored OpenDocument → extracted OpenDocumentCore(): removed the Task.Run wrapper (already on thread pool), captures values on thread pool, sets UI-bound properties via Dispatcher.UIThread.InvokeAsync
  - Refactored LoadPages: removed redundant inner Task.Run, builds all PageViewModels on thread pool, batch-adds to Pages via a single Dispatcher.UIThread.InvokeAsync
  - Refactored Clear command: captures disposables and clears UI properties on the UI thread in one batch, disposes off the UI thread

DocumentViewModel.TextSearch.cs
  - Replaced async partial void OnTextSearchChanged with a synchronous version calling SearchTextCommand.Execute(null) - eliminates the async void pattern; SearchText() already handles all cancellation and exceptions internally