### PR TITLE
Update package dependencies to latest versions

### DIFF
--- a/Caly.Android/Caly.Android.csproj
+++ b/Caly.Android/Caly.Android.csproj
@@ -18,7 +18,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Android" Version="12.0.1" />
+		<PackageReference Include="Avalonia.Android" Version="12.0.2" />
 		<PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
 	</ItemGroup>
 

--- a/Caly.Core/Caly.Core.csproj
+++ b/Caly.Core/Caly.Core.csproj
@@ -19,19 +19,19 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="12.0.1" />
-		<PackageReference Include="Avalonia.Skia" Version="12.0.1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+		<PackageReference Include="Avalonia" Version="12.0.2" />
+		<PackageReference Include="Avalonia.Skia" Version="12.0.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
 		<PackageReference Include="Caly.Avalonia.Controls.TreeDataGrid" Version="12.0.1" />
 		<PackageReference Include="Caly.Tabalonia" Version="12.0.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="Deadpikle.AvaloniaProgressRing" Version="0.11.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-		<PackageReference Include="PdfPig.Rendering.Skia" Version="0.1.14.2" />
-		<PackageReference Include="SkiaSharp" Version="3.119.3-preview.1.1" />
-		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.3-preview.1.1" />
-		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.3-preview.1.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+		<PackageReference Include="PdfPig.Rendering.Skia" Version="0.1.15.1-alpha001" />
+		<PackageReference Include="SkiaSharp" Version="3.119.4-preview.1.1" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4-preview.1.1" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4-preview.1.1" />
 		<PackageReference Include="System.Reactive" Version="6.1.0" />
 	</ItemGroup>
 

--- a/Caly.Desktop/Caly.Desktop.csproj
+++ b/Caly.Desktop/Caly.Desktop.csproj
@@ -84,7 +84,7 @@
 	</Target>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
 		<PackageReference Condition="'$(Configuration)'=='Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
 	</ItemGroup>
 

--- a/Caly.Pdf/Caly.Pdf.csproj
+++ b/Caly.Pdf/Caly.Pdf.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PdfPig" Version="0.1.15-alpha-20260328-e5c04" />
+		<PackageReference Include="PdfPig" Version="0.1.15-alpha-20260427-046a5" />
 		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
 	</ItemGroup>
 

--- a/Caly.iOS/Caly.iOS.csproj
+++ b/Caly.iOS/Caly.iOS.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.iOS" Version="12.0.1" />
+    <PackageReference Include="Avalonia.iOS" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Upgraded Avalonia packages (Android, iOS, Desktop, Core) from version 12.0.1 to 12.0.2.
- Updated Microsoft.Extensions.DependencyInjection to 10.0.7.
- Updated PdfPig.Rendering.Skia to 0.1.15.1-alpha001.
- Updated PdfPig to 0.1.15-alpha-20260427-046a5.
- Updated SkiaSharp and related packages to 3.119.4-preview.1.1.