### PR TITLE
Improve text layer: Do not ignore white space, improve type 3 font bbox

### DIFF
--- a/Caly.Pdf/Layout/CalyDocstrum.cs
+++ b/Caly.Pdf/Layout/CalyDocstrum.cs
@@ -55,7 +55,7 @@ public sealed class CalyDocstrum
             return Array.Empty<PdfTextBlock>();
         }
 
-        PdfWord[]? array = words?.Where(w => !w.Value.AsSpan().IsEmpty && !w.Value.AsSpan().IsWhiteSpace()).ToArray();
+        PdfWord[]? array = words?.Where(w => !w.Value.AsSpan().IsEmpty).ToArray();
 
         if (array is null || array.Length == 0)
         {

--- a/Caly.Pdf/Models/PdfTextLine.cs
+++ b/Caly.Pdf/Models/PdfTextLine.cs
@@ -254,76 +254,44 @@ public sealed class PdfTextLine : IPdfTextElement
 
     private static PdfRectangle GetBoundingBox90(IReadOnlyList<PdfWord> words)
     {
-        var t = double.MinValue;
-        var b = double.MaxValue;
+        GetCornerBounds(words, out double minX, out double maxX, out double minY, out double maxY);
 
-        var r = double.MaxValue;
-        var l = double.MinValue;
-
-        for (var i = 0; i < words.Count; ++i)
-        {
-            var word = words[i];
-
-            if (word.BoundingBox.BottomLeft.X < b)
-            {
-                b = word.BoundingBox.BottomLeft.X;
-            }
-
-            if (word.BoundingBox.BottomRight.Y < r)
-            {
-                r = word.BoundingBox.BottomRight.Y;
-            }
-
-            var right = word.BoundingBox.BottomLeft.X - word.BoundingBox.Height;
-            if (right > t)
-            {
-                t = right;
-            }
-
-            if (word.BoundingBox.BottomLeft.Y > l)
-            {
-                l = word.BoundingBox.BottomLeft.Y;
-            }
-        }
-
-        return new PdfRectangle(new PdfPoint(t, l), new PdfPoint(t, r),
-            new PdfPoint(b, l), new PdfPoint(b, r));
+        return new PdfRectangle(new PdfPoint(minX, maxY), new PdfPoint(minX, minY),
+            new PdfPoint(maxX, maxY), new PdfPoint(maxX, minY));
     }
 
     private static PdfRectangle GetBoundingBox270(IReadOnlyList<PdfWord> words)
     {
-        var t = double.MaxValue;
-        var b = double.MinValue;
-        var l = double.MaxValue;
-        var r = double.MinValue;
+        GetCornerBounds(words, out double minX, out double maxX, out double minY, out double maxY);
 
-        for (var i = 0; i < words.Count; i++)
+        return new PdfRectangle(new PdfPoint(maxX, minY), new PdfPoint(maxX, maxY),
+            new PdfPoint(minX, minY), new PdfPoint(minX, maxY));
+    }
+
+    private static void GetCornerBounds(IReadOnlyList<PdfWord> words,
+        out double minX, out double maxX, out double minY, out double maxY)
+    {
+        minX = double.MaxValue;
+        maxX = double.MinValue;
+        minY = double.MaxValue;
+        maxY = double.MinValue;
+
+        for (var i = 0; i < words.Count; ++i)
         {
-            var word = words[i];
-            if (word.BoundingBox.BottomLeft.X > b)
-            {
-                b = word.BoundingBox.BottomLeft.X;
-            }
-
-            if (word.BoundingBox.BottomLeft.Y < l)
-            {
-                l = word.BoundingBox.BottomLeft.Y;
-            }
-
-            var right = word.BoundingBox.BottomLeft.X + word.BoundingBox.Height;
-            if (right < t)
-            {
-                t = right;
-            }
-
-            if (word.BoundingBox.BottomRight.Y > r)
-            {
-                r = word.BoundingBox.BottomRight.Y;
-            }
+            var bb = words[i].BoundingBox;
+            Expand(bb.BottomLeft, ref minX, ref maxX, ref minY, ref maxY);
+            Expand(bb.BottomRight, ref minX, ref maxX, ref minY, ref maxY);
+            Expand(bb.TopLeft, ref minX, ref maxX, ref minY, ref maxY);
+            Expand(bb.TopRight, ref minX, ref maxX, ref minY, ref maxY);
         }
 
-        return new PdfRectangle(new PdfPoint(t, l), new PdfPoint(t, r),
-            new PdfPoint(b, l), new PdfPoint(b, r));
+        static void Expand(PdfPoint p, ref double minX, ref double maxX, ref double minY, ref double maxY)
+        {
+            if (p.X < minX) minX = p.X;
+            if (p.X > maxX) maxX = p.X;
+            if (p.Y < minY) minY = p.Y;
+            if (p.Y > maxY) maxY = p.Y;
+        }
     }
 
     private static PdfRectangle GetBoundingBoxOther(IReadOnlyList<PdfWord> words)

--- a/Caly.Pdf/Models/PdfWord.cs
+++ b/Caly.Pdf/Models/PdfWord.cs
@@ -473,77 +473,44 @@ public sealed class PdfWord : IPdfTextElement
 
     private static PdfRectangle GetBoundingBox90(IReadOnlyList<PdfLetter> letters)
     {
-        var t = double.MinValue;
-        var b = double.MaxValue;
+        GetCornerBounds(letters, out double minX, out double maxX, out double minY, out double maxY);
 
-        var r = double.MaxValue;
-        var l = double.MinValue;
-
-        for (var i = 0; i < letters.Count; ++i)
-        {
-            var letter = letters[i];
-
-            if (letter.StartBaseLine.X < b)
-            {
-                b = letter.StartBaseLine.X;
-            }
-
-            if (letter.EndBaseLine.Y < r)
-            {
-                r = letter.EndBaseLine.Y;
-            }
-
-            var right = letter.StartBaseLine.X - letter.BoundingBox.Height;
-            if (right > t)
-            {
-                t = right;
-            }
-
-            if (letter.BoundingBox.BottomLeft.Y > l)
-            {
-                l = letter.BoundingBox.BottomLeft.Y;
-            }
-        }
-
-        return new PdfRectangle(new PdfPoint(t, l), new PdfPoint(t, r),
-            new PdfPoint(b, l), new PdfPoint(b, r));
+        return new PdfRectangle(new PdfPoint(minX, maxY), new PdfPoint(minX, minY),
+            new PdfPoint(maxX, maxY), new PdfPoint(maxX, minY));
     }
 
     private static PdfRectangle GetBoundingBox270(IReadOnlyList<PdfLetter> letters)
     {
-        var t = double.MaxValue;
-        var b = double.MinValue;
-        var l = double.MaxValue;
-        var r = double.MinValue;
+        GetCornerBounds(letters, out double minX, out double maxX, out double minY, out double maxY);
 
-        for (var i = 0; i < letters.Count; i++)
+        return new PdfRectangle(new PdfPoint(maxX, minY), new PdfPoint(maxX, maxY),
+            new PdfPoint(minX, minY), new PdfPoint(minX, maxY));
+    }
+
+    private static void GetCornerBounds(IReadOnlyList<PdfLetter> letters,
+        out double minX, out double maxX, out double minY, out double maxY)
+    {
+        minX = double.MaxValue;
+        maxX = double.MinValue;
+        minY = double.MaxValue;
+        maxY = double.MinValue;
+
+        for (var i = 0; i < letters.Count; ++i)
         {
-            var letter = letters[i];
-
-            if (letter.StartBaseLine.X > b)
-            {
-                b = letter.StartBaseLine.X;
-            }
-
-            if (letter.StartBaseLine.Y < l)
-            {
-                l = letter.StartBaseLine.Y;
-            }
-
-            var right = letter.StartBaseLine.X + letter.BoundingBox.Height;
-            if (right < t)
-            {
-                t = right;
-            }
-
-            if (letter.BoundingBox.BottomRight.Y > r)
-            {
-                r = letter.BoundingBox.BottomRight.Y;
-            }
+            var bb = letters[i].BoundingBox;
+            Expand(bb.BottomLeft, ref minX, ref maxX, ref minY, ref maxY);
+            Expand(bb.BottomRight, ref minX, ref maxX, ref minY, ref maxY);
+            Expand(bb.TopLeft, ref minX, ref maxX, ref minY, ref maxY);
+            Expand(bb.TopRight, ref minX, ref maxX, ref minY, ref maxY);
         }
 
-        return new PdfRectangle(new PdfPoint(t, l), new PdfPoint(t, r),
-            new PdfPoint(b, l), new PdfPoint(b, r));
+        static void Expand(PdfPoint p, ref double minX, ref double maxX, ref double minY, ref double maxY)
+        {
+            if (p.X < minX) minX = p.X;
+            if (p.X > maxX) maxX = p.X;
+            if (p.Y < minY) minY = p.Y;
+            if (p.Y > maxY) maxY = p.Y;
+        }
     }
 
     private static PdfRectangle GetBoundingBoxOther(IReadOnlyList<PdfLetter> letters)

--- a/Caly.Pdf/PdfTextLayerHelper.cs
+++ b/Caly.Pdf/PdfTextLayerHelper.cs
@@ -311,5 +311,47 @@ namespace Caly.Pdf
                 new PdfPoint(minX, bottomY),
                 new PdfPoint(maxX, bottomY));
         }
+
+        /// <summary>
+        /// Whether the rectangle is mirrored (reflected) rather than a pure rotation of an
+        /// upright rectangle, i.e. "flipped on the X axis", with its top edge below its bottom edge.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Coordinates are assumed to be in the text layer's top-left origin (inverse-Y) space, where a
+        /// correctly-oriented box has its <see cref="PdfRectangle.TopLeft"/> / <see cref="PdfRectangle.TopRight"/>
+        /// visually <em>above</em> (smaller Y than) its <see cref="PdfRectangle.BottomLeft"/> /
+        /// <see cref="PdfRectangle.BottomRight"/>.
+        /// </para>
+        /// </remarks>
+        public static bool IsMirrored(this PdfRectangle rectangle)
+        {
+            double baseX = rectangle.BottomRight.X - rectangle.BottomLeft.X;
+            double baseY = rectangle.BottomRight.Y - rectangle.BottomLeft.Y;
+            double leftX = rectangle.TopLeft.X - rectangle.BottomLeft.X;
+            double leftY = rectangle.TopLeft.Y - rectangle.BottomLeft.Y;
+
+            return baseX * leftY - baseY * leftX > 0;
+        }
+
+        /// <summary>
+        /// Returns an equivalent rectangle that is not <see cref="IsMirrored">mirrored</see>: it covers the
+        /// exact same four corner points, but the top and bottom corners are swapped so the labels are
+        /// upright again. If the rectangle is already upright it is returned unchanged.
+        /// </summary>
+        public static PdfRectangle UnMirror(this PdfRectangle rectangle)
+        {
+            if (!rectangle.IsMirrored())
+            {
+                return rectangle;
+            }
+
+            // Swap top <-> bottom corners (mirror back across the baseline).
+            return new PdfRectangle(
+                rectangle.BottomLeft,   // -> TopLeft
+                rectangle.BottomRight,  // -> TopRight
+                rectangle.TopLeft,      // -> BottomLeft
+                rectangle.TopRight);    // -> BottomRight
+        }
     }
 }

--- a/Caly.Pdf/TextLayer/TextLayerStreamProcessor.cs
+++ b/Caly.Pdf/TextLayer/TextLayerStreamProcessor.cs
@@ -51,16 +51,7 @@ namespace Caly.Pdf.TextLayer
         private readonly double _ppiScale;
 
         private readonly AnnotationProvider _annotationProvider;
-
-        /// <summary>
-        /// Cache of Type 3 glyph bounding boxes (from the CharProc's d1 operator),
-        /// keyed by font instance + character code. A <c>null</c> value means the
-        /// CharProc was parsed and either had no d1 or could not be retrieved, so
-        /// the fallback rect should be used. Avoids re-decoding and re-parsing the
-        /// same CharProc stream once per occurrence of the glyph.
-        /// </summary>
-        private readonly Dictionary<(IType3Font Font, int Code), PdfRectangle?> _type3GlyphBoxCache = new();
-
+        
         /// <summary>
         /// The replacement text (/ActualText) of the marked-content sequence currently being
         /// processed, or <see langword="null"/> when none is active. See the PDF specification,
@@ -201,64 +192,51 @@ namespace Caly.Pdf.TextLayer
              * unit in user space, or 1 ⁄ 72 inch. Starting with PDF 1.6, the size of this unit may be specified as greater than
              * 1 ⁄ 72 inch by means of the UserUnit entry of the page dictionary.
              */
-            
-            PdfRectangle? bbox = null;
-            if (font is IType3Font type3Font)
-            {
-                bbox = GetOrComputeType3GlyphBoundingBox(type3Font, code);
-            }
-            
-            bbox ??= new PdfRectangle(0, 0, characterBoundingBox.Width, Math.Max(font.GetAscent(), UserSpaceUnit.PointMultiples));
 
-            var transformedPdfBounds = InverseYAxis(PerformantRectangleTransformer
-                    .Transform(renderingMatrix,
-                        textMatrix,
-                        transformationMatrix,
-                        bbox.Value),
-                _pageHeight);
+            PdfRectangle boundingBox;
+
+            if (font is IType3Font)
+            {
+                // NB: Type 3 fonts are a mess
+                double width = characterBoundingBox.GlyphBounds.BottomRight.X -
+                               characterBoundingBox.GlyphBounds.BottomLeft.X;
+                var baselineBounds = InverseYAxis(PerformantRectangleTransformer
+                        .Transform(renderingMatrix,
+                            textMatrix,
+                            transformationMatrix,
+                            new PdfRectangle(0, 0, width, UserSpaceUnit.PointMultiples)),
+                    _pageHeight);
+
+                boundingBox = InverseYAxis(PerformantRectangleTransformer
+                        .Transform(renderingMatrix,
+                            textMatrix,
+                            transformationMatrix,
+                            characterBoundingBox.GlyphBounds),
+                    _pageHeight)
+                    .UnMirror(); // We make sure the bbox is not mirrored, happens a lot for type 3 fonts
+
+                boundingBox = new PdfRectangle(boundingBox.TopLeft, boundingBox.TopRight,
+                    baselineBounds.BottomLeft, baselineBounds.BottomRight);
+            }
+            else
+            {
+                var bbox = new PdfRectangle(0, 0, characterBoundingBox.Width,
+                    Math.Max(font.GetAscent(), UserSpaceUnit.PointMultiples));
+
+                boundingBox = InverseYAxis(PerformantRectangleTransformer
+                        .Transform(renderingMatrix,
+                            textMatrix,
+                            transformationMatrix,
+                            bbox),
+                    _pageHeight);
+            }
 
             var letter = new PdfLetter(unicode,
-                transformedPdfBounds,
+                boundingBox,
                 (float)pointSize,
                 TextSequence);
 
             _letters.Add(letter);
-        }
-
-        private PdfRectangle? GetOrComputeType3GlyphBoundingBox(IType3Font type3Font, int code)
-        {
-            var key = (type3Font, code);
-            if (_type3GlyphBoxCache.TryGetValue(key, out var cached))
-            {
-                return cached;
-            }
-
-            PdfRectangle? result = null;
-            if (type3Font.TryGetCharProc(code, out var charProcStream))
-            {
-                var contentBytes = charProcStream.Decode(FilterProvider, PdfScanner);
-                var operations = PageContentParser.Parse(PageNumber,
-                    new MemoryInputBytes(contentBytes),
-                    ParsingOptions.Logger);
-
-                for (int i = 0; i < operations.Count; ++i)
-                {
-                    if (operations[i] is Type3SetGlyphWidthAndBoundingBox d1)
-                    {
-                        double left = Math.Min(d1.LowerLeftX, d1.UpperRightX);
-                        double right = Math.Max(d1.LowerLeftX, d1.UpperRightX);
-                        double top = Math.Max(d1.LowerLeftY, d1.UpperRightY);
-                        double bottom = Math.Min(d1.LowerLeftY, d1.UpperRightY);
-                        result = type3Font.GetFontMatrix()
-                            .Transform(new PdfRectangle(left, top, right, bottom))
-                            .NormaliseCaly();
-                        break;
-                    }
-                }
-            }
-
-            _type3GlyphBoxCache[key] = result;
-            return result;
         }
 
         #region BaseStreamProcessor overrides

--- a/Caly.Tests/PdfRectangleExtensionsTests.cs
+++ b/Caly.Tests/PdfRectangleExtensionsTests.cs
@@ -1,0 +1,161 @@
+﻿using Caly.Pdf;
+using Caly.Pdf.Models;
+using UglyToad.PdfPig.Core;
+
+namespace Caly.Tests;
+
+public class PdfRectangleExtensionsTests
+{
+    // Rotates a point by angleDeg (counter-clockwise) about (cx, cy). A proper rotation
+    // (determinant +1) preserves handedness, so it never changes the flipped state.
+    private static PdfPoint Rotate(PdfPoint p, double cx, double cy, double angleDeg)
+    {
+        double a = angleDeg * Math.PI / 180.0;
+        double cos = Math.Cos(a), sin = Math.Sin(a);
+        double dx = p.X - cx, dy = p.Y - cy;
+        return new PdfPoint(cx + dx * cos - dy * sin, cy + dx * sin + dy * cos);
+    }
+
+    /// <summary>
+    /// Builds a w x h rectangle centred at (cx, cy) in the text layer's top-left origin (inverse-Y)
+    /// space, optionally flipped across its baseline, then rotated by <paramref name="angleDeg"/>.
+    /// </summary>
+    private static PdfRectangle Make(double cx, double cy, double w, double h, double angleDeg, bool flipped)
+    {
+        double l = cx - w / 2, r = cx + w / 2;
+        double top = cy - h / 2;     // smaller Y is visually higher (inverse-Y)
+        double bottom = cy + h / 2;
+
+        // Upright: top corners have the smaller Y. Flipped: top/bottom Y swapped.
+        double topY = flipped ? bottom : top;
+        double bottomY = flipped ? top : bottom;
+
+        var tl = new PdfPoint(l, topY);
+        var tr = new PdfPoint(r, topY);
+        var bl = new PdfPoint(l, bottomY);
+        var br = new PdfPoint(r, bottomY);
+
+        return new PdfRectangle(
+            Rotate(tl, cx, cy, angleDeg), Rotate(tr, cx, cy, angleDeg),
+            Rotate(bl, cx, cy, angleDeg), Rotate(br, cx, cy, angleDeg));
+    }
+
+    private static IEnumerable<double> Angles =>
+        new double[] { 0, 34, 90, 137, 180, 215, 270, 313, -34, -90 };
+
+    [Fact]
+    public void UprightRectangles_AreNotFlipped_AtEveryRotation()
+    {
+        foreach (var angle in Angles)
+        {
+            var rect = Make(100, 200, 40, 16, angle, flipped: false);
+            Assert.False(rect.IsMirrored(), $"upright @ {angle}° reported flipped");
+        }
+    }
+
+    [Fact]
+    public void FlippedRectangles_AreFlipped_AtEveryRotation()
+    {
+        foreach (var angle in Angles)
+        {
+            var rect = Make(100, 200, 40, 16, angle, flipped: true);
+            Assert.True(rect.IsMirrored(), $"flipped @ {angle}° not detected");
+        }
+    }
+
+    [Fact]
+    public void Unflip_MakesFlippedUpright_AtEveryRotation_PreservingGeometry()
+    {
+        foreach (var angle in Angles)
+        {
+            var flipped = Make(100, 200, 40, 16, angle, flipped: true);
+            var fixedRect = flipped.UnMirror();
+
+            Assert.True(flipped.IsMirrored(), $"precondition @ {angle}°");
+            Assert.False(fixedRect.IsMirrored(), $"still flipped after Unflip @ {angle}°");
+
+            // Same region (same four corner points as a set) and same size.
+            Assert.Equal(flipped.Width, fixedRect.Width, 6);
+            Assert.Equal(flipped.Height, fixedRect.Height, 6);
+            AssertSameCornerSet(flipped, fixedRect);
+
+            // Reading direction (rotation of the bottom edge) is preserved.
+            Assert.Equal(flipped.Rotation, fixedRect.Rotation, 6);
+        }
+    }
+
+    [Fact]
+    public void Unflip_IsNoOp_WhenAlreadyUpright()
+    {
+        foreach (var angle in Angles)
+        {
+            var upright = Make(100, 200, 40, 16, angle, flipped: false);
+            var result = upright.UnMirror();
+            Assert.Equal(upright, result);
+        }
+    }
+
+    [Fact]
+    public void Unflip_IsIdempotent()
+    {
+        var flipped = Make(100, 200, 40, 16, 34, flipped: true);
+        var once = flipped.UnMirror();
+        var twice = once.UnMirror();
+        Assert.Equal(once, twice);
+    }
+    
+    // ---- Real captured glyph boxes (text layer, top-left origin) ----
+
+    [Fact]
+    public void RealUprightGlyph_IsNotFlipped()
+    {
+        // test_a-5.pdf 'P'
+        var rect = new PdfRectangle(
+            new PdfPoint(36.0, 33.8), new PdfPoint(42.0, 33.8),
+            new PdfPoint(36.0, 43.8), new PdfPoint(42.0, 43.8));
+        Assert.Equal(0, rect.Rotation, 3);
+        Assert.False(rect.IsMirrored());
+    }
+
+    [Fact]
+    public void RealFlippedGlyph_WithZeroRotation_IsFlipped()
+    {
+        // GHOSTSCRIPT-695513-0.pdf '1' — rotation reads 0 but the box is mirrored.
+        var rect = new PdfRectangle(
+            new PdfPoint(95.6, 145.7), new PdfPoint(118.7, 145.7),
+            new PdfPoint(95.6, 128.3), new PdfPoint(118.7, 128.3));
+        Assert.Equal(0, rect.Rotation, 3);
+        Assert.True(rect.IsMirrored());
+        Assert.False(rect.UnMirror().IsMirrored());
+    }
+
+    [Fact]
+    public void RealUprightRotate90Glyph_IsNotFlipped()
+    {
+        // GHOSTSCRIPT-697234-0.pdf — vertical (Rotate90) text.
+        var rect = new PdfRectangle(
+            new PdfPoint(22.3, 198.5), new PdfPoint(22.3, 188.3),
+            new PdfPoint(32.9, 198.5), new PdfPoint(32.9, 188.3));
+        Assert.False(rect.IsMirrored());
+    }
+
+    [Fact]
+    public void DegenerateBox_IsNotFlipped()
+    {
+        var rect = new PdfRectangle(
+            new PdfPoint(10.0, 10.0), new PdfPoint(10.0, 10.0),
+            new PdfPoint(10.0, 10.0), new PdfPoint(10.0, 10.0));
+        Assert.False(rect.IsMirrored());
+        Assert.Equal(rect, rect.UnMirror());
+    }
+
+    private static void AssertSameCornerSet(PdfRectangle a, PdfRectangle b)
+    {
+        var setA = new[] { a.TopLeft, a.TopRight, a.BottomLeft, a.BottomRight };
+        var setB = new[] { b.TopLeft, b.TopRight, b.BottomLeft, b.BottomRight };
+        foreach (var pa in setA)
+        {
+            Assert.Contains(setB, pb => Math.Abs(pa.X - pb.X) < 1e-6 && Math.Abs(pa.Y - pb.Y) < 1e-6);
+        }
+    }
+}

--- a/Caly.Tests/RotatedBoundingBoxTests.cs
+++ b/Caly.Tests/RotatedBoundingBoxTests.cs
@@ -1,0 +1,98 @@
+using Caly.Pdf.Models;
+using UglyToad.PdfPig.Content;
+using UglyToad.PdfPig.Core;
+
+namespace Caly.Tests;
+
+/// <summary>
+/// Regression tests for rotated word/line bounding boxes when constituent boxes have
+/// non-uniform (or degenerate) heights — as produced by tight Type 3 glyph bounds, where
+/// no-ink glyphs (spaces) have an almost-zero bounding box. The cross-axis thickness of a
+/// Rotate90/Rotate270 box must bound every glyph, not collapse to the shortest one.
+/// </summary>
+public class RotatedBoundingBoxTests
+{
+    // Rotate90: baseline runs vertically at X = baseX, reading downward (Y decreasing).
+    // The glyph rises toward smaller X (top edge at baseX - thickness).
+    private static PdfLetter Rot90Letter(string v, double baseX, double yStart, double length, double thickness)
+    {
+        var bl = new PdfPoint(baseX, yStart);
+        var br = new PdfPoint(baseX, yStart - length);
+        var tl = new PdfPoint(baseX - thickness, yStart);
+        var tr = new PdfPoint(baseX - thickness, yStart - length);
+        return new PdfLetter(v, new PdfRectangle(tl, tr, bl, br), 10f, 0);
+    }
+
+    // Rotate270: baseline runs vertically at X = baseX, reading upward (Y increasing).
+    // The glyph rises toward larger X (top edge at baseX + thickness).
+    private static PdfLetter Rot270Letter(string v, double baseX, double yStart, double length, double thickness)
+    {
+        var bl = new PdfPoint(baseX, yStart);
+        var br = new PdfPoint(baseX, yStart + length);
+        var tl = new PdfPoint(baseX + thickness, yStart);
+        var tr = new PdfPoint(baseX + thickness, yStart + length);
+        return new PdfLetter(v, new PdfRectangle(tl, tr, bl, br), 10f, 0);
+    }
+
+    [Fact]
+    public void Rotate90_Line_ThicknessNotCollapsedByDegenerateSpaceWord()
+    {
+        var word = new PdfWord([Rot90Letter("A", 100, 200, 8, 6.0)]);
+        var space = new PdfWord([Rot90Letter(" ", 100, 190, 0.1, 0.1)]); // no-ink glyph
+        Assert.Equal(TextOrientation.Rotate90, word.TextOrientation);
+        Assert.Equal(TextOrientation.Rotate90, space.TextOrientation);
+
+        var line = new PdfTextLine([word, space]);
+
+        Assert.Equal(TextOrientation.Rotate90, line.TextOrientation);
+        // The line must be as thick as the real glyph (~6), not the degenerate space (~0.1).
+        Assert.True(line.BoundingBox.Height >= 5.5,
+            $"Rotate90 line collapsed: Height={line.BoundingBox.Height:0.00}");
+    }
+
+    [Fact]
+    public void Rotate270_Line_ThicknessNotCollapsedByDegenerateSpaceWord()
+    {
+        var word = new PdfWord([Rot270Letter("A", 100, 200, 8, 6.0)]);
+        var space = new PdfWord([Rot270Letter(" ", 100, 210, 0.1, 0.1)]);
+        Assert.Equal(TextOrientation.Rotate270, word.TextOrientation);
+        Assert.Equal(TextOrientation.Rotate270, space.TextOrientation);
+
+        var line = new PdfTextLine([word, space]);
+
+        Assert.Equal(TextOrientation.Rotate270, line.TextOrientation);
+        Assert.True(line.BoundingBox.Height >= 5.5,
+            $"Rotate270 line collapsed: Height={line.BoundingBox.Height:0.00}");
+    }
+
+    [Fact]
+    public void Rotate90_Word_ThicknessBoundsTallestLetter()
+    {
+        // Letters of differing tight heights, like real Type 3 glyphs.
+        var word = new PdfWord([
+            Rot90Letter("A", 100, 200, 4, 6.8),
+            Rot90Letter(" ", 100, 196, 0.1, 0.1),
+            Rot90Letter("B", 100, 195, 4, 5.9),
+        ]);
+
+        Assert.Equal(TextOrientation.Rotate90, word.TextOrientation);
+        // Must bound the tallest letter (6.8), not collapse to the space (0.1).
+        Assert.True(word.BoundingBox.Height >= 6.5,
+            $"Rotate90 word too thin: Height={word.BoundingBox.Height:0.00}");
+    }
+
+    [Fact]
+    public void Rotate90_Line_ReadingLengthAndRotationPreserved()
+    {
+        var word = new PdfWord([Rot90Letter("A", 100, 200, 8, 6.0)]);
+        var space = new PdfWord([Rot90Letter(" ", 100, 190, 0.1, 0.1)]);
+        var line = new PdfTextLine([word, space]);
+
+        // Reading direction spans Y from 200 (start) down to ~189.9 (end) => ~10.1
+        Assert.Equal(10.1, line.BoundingBox.Width, 1);
+        Assert.Equal(-90.0, line.BoundingBox.Rotation, 1);
+        // BottomLeft is the baseline start (largest X, largest Y).
+        Assert.Equal(100.0, line.BoundingBox.BottomLeft.X, 1);
+        Assert.Equal(200.0, line.BoundingBox.BottomLeft.Y, 1);
+    }
+}


### PR DESCRIPTION
Fix type 3 font bbox. Now the below documents have correct bboxes
[GHOSTSCRIPT-692564-0.pdf](https://github.com/user-attachments/files/28793757/GHOSTSCRIPT-692564-0.pdf)
[GHOSTSCRIPT-695513-0.pdf](https://github.com/user-attachments/files/28793760/GHOSTSCRIPT-695513-0.pdf)
[GHOSTSCRIPT-697234-0.pdf](https://github.com/user-attachments/files/28793762/GHOSTSCRIPT-697234-0.pdf)
[GHOSTSCRIPT-697984-3.pdf](https://github.com/user-attachments/files/28793763/GHOSTSCRIPT-697984-3.pdf)
[GHOSTSCRIPT-700288-1.pdf](https://github.com/user-attachments/files/28793764/GHOSTSCRIPT-700288-1.pdf)
[test_a-5.pdf](https://github.com/user-attachments/files/28793765/test_a-5.pdf)
[caly-issues-56-1.pdf](https://github.com/user-attachments/files/28793766/caly-issues-56-1.pdf)
