### PR TITLE
Remove duplicated control plumbing between DocumentControl and PageItemsControl and extract ZoomPanController

### DIFF
--- a/Caly.Core/Controls/DocumentControl.axaml
+++ b/Caly.Core/Controls/DocumentControl.axaml
@@ -11,20 +11,11 @@
 
 	<ControlTheme x:Key="{x:Type controls:DocumentControl}" TargetType="controls:DocumentControl" x:DataType="vm:DocumentViewModel">
 		<Setter Property="Exception" Value="{Binding Exception}"/>
-        <Setter Property="RefreshPages" Value="{Binding RefreshPagesCommand}"/>
-        <Setter Property="TextSelection" Value="{Binding TextSelection}"/>
-		<Setter Property="SelectedPageNumber" Value="{Binding SelectedPageNumber, Mode=TwoWay}"/>
-        <Setter Property="RealisedPages" Value="{Binding RealisedPages}"/>
-        <Setter Property="VisiblePages" Value="{Binding VisiblePages}"/>
-		<Setter Property="ItemsSource" Value="{Binding Pages}"/>
-		<Setter Property="PageCount" Value="{Binding PageCount}"/>
-		<Setter Property="ZoomLevel" Value="{Binding ZoomLevel, Mode=TwoWay}"/>
-        <Setter Property="ScrollOffset" Value="{Binding ScrollOffset, Mode=TwoWay}"/>
+		<Setter Property="SelectedPageNumber" Value="{Binding SelectedPageNumber}"/>
 		<Setter Property="SelectedBookmark" Value="{Binding SelectedBookmark, Mode=OneWay}"/>
 		<Setter Property="SelectedTextSearchResult" Value="{Binding SelectedTextSearchResult, Mode=OneWay}"/>
 		<Setter Property="UseLayoutRounding" Value="True"/>
 		<Setter Property="ClearSelection" Value="{Binding ClearSelectionCommand}"/>
-        <Setter Property="DocumentChanged" Value="{Binding ActivatedCommand}"/>
 
 		<Setter Property="ContextFlyout">
 			<MenuFlyout>
@@ -45,17 +36,7 @@
 
                     <!-- The pages control -->
                     <controls:PageItemsControl Name="PART_PageItemsControl"
-                                               HorizontalAlignment="Stretch"
-                                               ItemsSource="{TemplateBinding ItemsSource}"
-                                               PageCount="{TemplateBinding PageCount}"
-                                               SelectedPageNumber="{TemplateBinding SelectedPageNumber, Mode=TwoWay}"
-                                               ZoomLevel="{TemplateBinding ZoomLevel, Mode=TwoWay}"
-                                               TextSelection="{TemplateBinding TextSelection}"
-                                               ClearSelection="{TemplateBinding ClearSelection}"
-                                               RealisedPages="{TemplateBinding RealisedPages, Mode=TwoWay}"
-                                               VisiblePages="{TemplateBinding VisiblePages, Mode=TwoWay}"
-                                               ScrollOffset="{TemplateBinding ScrollOffset, Mode=TwoWay}"
-                                               RefreshPages="{TemplateBinding RefreshPages}"/>
+                                               HorizontalAlignment="Stretch"/>
 
                     <Grid IsVisible="{Binding !Pages.Count}">
                         <!-- Progress Ring for when the document is opening -->

--- a/Caly.Core/Controls/DocumentControl.axaml.cs
+++ b/Caly.Core/Controls/DocumentControl.axaml.cs
@@ -18,20 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
-using System.Collections;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Data;
 using Avalonia.Input;
-using Avalonia.VisualTree;
 using Caly.Core.Models;
 using Caly.Core.Utilities;
 
 namespace Caly.Core.Controls;
+
+/*
+ * Document state (pages, zoom, scroll, selection) is bound directly onto the
+ * inner PageItemsControl by its control theme; this control only reacts to
+ * navigation triggers (selected page, bookmark, search result) and clears the
+ * text selection on background clicks.
+ */
 
 /// <summary>
 /// Control that represents a PDF document.
@@ -42,54 +45,10 @@ public sealed class DocumentControl : CalyTemplatedControl
     private PageItemsControl? _pageItemsControl;
 
     /// <summary>
-    /// Defines the <see cref="ItemsSource"/> property.
-    /// </summary>
-    public static readonly StyledProperty<IEnumerable?> ItemsSourceProperty =
-        AvaloniaProperty.Register<DocumentControl, IEnumerable?>(nameof(ItemsSource));
-
-    /// <summary>
-    /// Defines the <see cref="PageCount"/> property.
-    /// </summary>
-    public static readonly StyledProperty<int> PageCountProperty =
-        AvaloniaProperty.Register<DocumentControl, int>(nameof(PageCount), 0);
-
-    /// <summary>
-    /// Defines the <see cref="ZoomLevel"/> property.
-    /// </summary>
-    public static readonly StyledProperty<double> ZoomLevelProperty =
-        AvaloniaProperty.Register<DocumentControl, double>(nameof(ZoomLevel), 1,
-            defaultBindingMode: BindingMode.TwoWay);
-
-    /// <summary>
-    /// Defines the <see cref="ScrollOffset"/> property.
-    /// </summary>
-    public static readonly StyledProperty<Vector> ScrollOffsetProperty =
-        AvaloniaProperty.Register<DocumentControl, Vector>(nameof(ScrollOffset),
-            defaultBindingMode: BindingMode.TwoWay);
-
-    /// <summary>
     /// Defines the <see cref="SelectedPageNumber"/> property. Starts at 1.
     /// </summary>
     public static readonly StyledProperty<int?> SelectedPageNumberProperty =
-        AvaloniaProperty.Register<DocumentControl, int?>(nameof(SelectedPageNumber),
-            defaultBindingMode: BindingMode.TwoWay);
-
-    public static readonly StyledProperty<ICommand?> RefreshPagesProperty =
-        AvaloniaProperty.Register<DocumentControl, ICommand?>(nameof(RefreshPages));
-
-    /// <summary>
-    /// Defines the <see cref="VisiblePages"/> property. Starts at 1.
-    /// </summary>
-    public static readonly StyledProperty<Range?> VisiblePagesProperty =
-        AvaloniaProperty.Register<DocumentControl, Range?>(nameof(VisiblePages),
-            defaultBindingMode: BindingMode.TwoWay);
-
-    /// <summary>
-    /// Defines the <see cref="RealisedPages"/> property. Starts at 1.
-    /// </summary>
-    public static readonly StyledProperty<Range?> RealisedPagesProperty =
-        AvaloniaProperty.Register<DocumentControl, Range?>(nameof(RealisedPages),
-            defaultBindingMode: BindingMode.TwoWay);
+        AvaloniaProperty.Register<DocumentControl, int?>(nameof(SelectedPageNumber));
 
     /// <summary>
     /// Defines the <see cref="SelectedBookmark"/> property.
@@ -104,86 +63,15 @@ public sealed class DocumentControl : CalyTemplatedControl
         AvaloniaProperty.Register<DocumentControl, TextSearchResult?>(nameof(SelectedTextSearchResult));
 
     /// <summary>
-    /// Defines the <see cref="TextSelection"/> property.
-    /// </summary>
-    public static readonly StyledProperty<TextSelection?> TextSelectionProperty =
-        AvaloniaProperty.Register<DocumentControl, TextSelection?>(nameof(TextSelection));
-
-    /// <summary>
-    /// Defines the <see cref="DocumentChanged"/> property.
-    /// </summary>
-    public static readonly StyledProperty<ICommand?> DocumentChangedProperty =
-        AvaloniaProperty.Register<DocumentControl, ICommand?>(nameof(DocumentChanged));
-
-    /// <summary>
     /// Defines the <see cref="ClearSelection"/> property.
     /// </summary>
     public static readonly StyledProperty<ICommand?> ClearSelectionProperty =
         AvaloniaProperty.Register<DocumentControl, ICommand?>(nameof(ClearSelection));
 
-    /// <summary>
-    /// Starts at 1.
-    /// </summary>
-    public Range? VisiblePages
-    {
-        get => GetValue(VisiblePagesProperty);
-        set => SetValue(VisiblePagesProperty, value);
-    }
-
-    /// <summary>
-    /// Starts at 1.
-    /// </summary>
-    public Range? RealisedPages
-    {
-        get => GetValue(RealisedPagesProperty);
-        set => SetValue(RealisedPagesProperty, value);
-    }
-
-    public ICommand? RefreshPages
-    {
-        get => GetValue(RefreshPagesProperty);
-        set => SetValue(RefreshPagesProperty, value);
-    }
-
-    public TextSelection? TextSelection
-    {
-        get => GetValue(TextSelectionProperty);
-        set => SetValue(TextSelectionProperty, value);
-    }
-
-    public ICommand? DocumentChanged
-    {
-        get => GetValue(DocumentChangedProperty);
-        set => SetValue(DocumentChangedProperty, value);
-    }
-
     public ICommand? ClearSelection
     {
         get => GetValue(ClearSelectionProperty);
         set => SetValue(ClearSelectionProperty, value);
-    }
-
-    public int PageCount
-    {
-        get => GetValue(PageCountProperty);
-        set => SetValue(PageCountProperty, value);
-    }
-
-    public double ZoomLevel
-    {
-        get => GetValue(ZoomLevelProperty);
-        set => SetValue(ZoomLevelProperty, value);
-    }
-
-    /// <summary>
-    /// Scroll offset persisted across tab switches. Y is relative to
-    /// <see cref="SelectedPageNumber"/>'s top; both components are in unscaled
-    /// document coordinates.
-    /// </summary>
-    public Vector ScrollOffset
-    {
-        get => GetValue(ScrollOffsetProperty);
-        set => SetValue(ScrollOffsetProperty, value);
     }
 
     /// <summary>
@@ -205,12 +93,6 @@ public sealed class DocumentControl : CalyTemplatedControl
     {
         get => GetValue(SelectedTextSearchResultProperty);
         set => SetValue(SelectedTextSearchResultProperty, value);
-    }
-
-    public IEnumerable? ItemsSource
-    {
-        get => GetValue(ItemsSourceProperty);
-        set => SetValue(ItemsSourceProperty, value);
     }
 
     public DocumentControl()
@@ -240,12 +122,7 @@ public sealed class DocumentControl : CalyTemplatedControl
     {
         base.OnPropertyChanged(change);
 
-        if (change.Property == DocumentChangedProperty)
-        {
-            System.Diagnostics.Debug.WriteLine("Active Document changed.");
-            DocumentChanged?.Execute(null);
-        }
-        else if (change.Property == SelectedPageNumberProperty)
+        if (change.Property == SelectedPageNumberProperty)
         {
             if (change.NewValue is int p)
             {
@@ -280,40 +157,6 @@ public sealed class DocumentControl : CalyTemplatedControl
                 }
             }
         }
-        else if (change.Property == ZoomLevelProperty)
-        {
-            if (_pageItemsControl?.LayoutTransform is null || change.NewValue is not double newZoom)
-            {
-                return;
-            }
-
-            if (!_pageItemsControl.LayoutTransform.IsAttachedToVisualTree())
-            {
-                return;
-            }
-
-            var currentScale = _pageItemsControl.LayoutTransform.LayoutTransform?.Value.M11;
-            if (currentScale.HasValue && Math.Abs(currentScale.Value - newZoom) < 1e-9)
-            {
-                return; // Ignore as no change in zoom level
-            }
-
-            double dZoom = newZoom / (double?)change.OldValue ?? 1.0;
-
-            double w = 0, h = 0;
-            if (!_pageItemsControl.DesiredSize.IsEmpty())
-            {
-                _pageItemsControl.DesiredSize.Deconstruct(out w, out h);
-            }
-            else if (!_pageItemsControl.Bounds.Size.IsEmpty())
-            {
-                _pageItemsControl.Bounds.Size.Deconstruct(out w, out h);
-            }
-
-            var pixelPoint = this.PointToScreen(new Point((int)(w / 2.0), (int)(h / 2.0)));
-            var point = _pageItemsControl.LayoutTransform.PointToClient(pixelPoint);
-            _pageItemsControl.ZoomTo(dZoom, point);
-        }
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -333,20 +176,5 @@ public sealed class DocumentControl : CalyTemplatedControl
     public void GoToPage(int pageNumber, double yOffset = 0, bool offsetPdfCoord = false)
     {
         _pageItemsControl?.GoToPage(pageNumber, yOffset, offsetPdfCoord);
-    }
-
-    /// <summary>
-    /// Get the page control for the page number.
-    /// </summary>
-    /// <param name="pageNumber">The page number. Starts at 1.</param>
-    /// <returns>The page control, or <c>null</c> if not found.</returns>
-    public PageItem? GetPageItem(int pageNumber)
-    {
-        return _pageItemsControl?.GetPageItem(pageNumber);
-    }
-
-    public PageItem? GetPageItemOver(PointerEventArgs e)
-    {
-        return _pageItemsControl?.GetPageItemOver(e);
     }
 }

--- a/Caly.Core/Controls/PageItemsControl.axaml
+++ b/Caly.Core/Controls/PageItemsControl.axaml
@@ -16,8 +16,18 @@
                   TargetType="controls:PageItemsControl"
                   x:DataType="vm:DocumentViewModel">
 
+        <Setter Property="ItemsSource" Value="{Binding Pages}"/>
+        <Setter Property="PageCount" Value="{Binding PageCount}"/>
+        <Setter Property="SelectedPageNumber" Value="{Binding SelectedPageNumber, Mode=TwoWay}"/>
         <Setter Property="MinZoomLevel" Value="{Binding MinZoomLevel}"/>
 		<Setter Property="MaxZoomLevel" Value="{Binding MaxZoomLevel}"/>
+        <Setter Property="ZoomLevel" Value="{Binding ZoomLevel, Mode=TwoWay}"/>
+        <Setter Property="ScrollOffset" Value="{Binding ScrollOffset, Mode=TwoWay}"/>
+        <Setter Property="TextSelection" Value="{Binding TextSelection}"/>
+        <Setter Property="RealisedPages" Value="{Binding RealisedPages, Mode=TwoWay}"/>
+        <Setter Property="VisiblePages" Value="{Binding VisiblePages, Mode=TwoWay}"/>
+        <Setter Property="RefreshPages" Value="{Binding RefreshPagesCommand}"/>
+        <Setter Property="ClearSelection" Value="{Binding ClearSelectionCommand}"/>
 		<Setter Property="InteractiveActionOver" Value="{Binding InteractiveActionOver}"/>
 
 		<Setter Property="Template">

--- a/Caly.Core/Controls/PageItemsControl.axaml.cs
+++ b/Caly.Core/Controls/PageItemsControl.axaml.cs
@@ -27,7 +27,6 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
-using Avalonia.Media.Transformation;
 using Caly.Core.Models;
 using Caly.Core.Utilities;
 using Caly.Pdf;
@@ -42,14 +41,12 @@ using UglyToad.PdfPig.Core;
 namespace Caly.Core.Controls;
 
 /// <summary>
-/// Control that displays the PDF document pages.
+/// Control that displays the PDF document pages and owns the document state (pages, zoom, scroll, selection).
 /// </summary>
 [TemplatePart("PART_ScrollViewer", typeof(ScrollViewer))]
 [TemplatePart("PART_LayoutTransformControl", typeof(LayoutTransformControl))]
 public sealed class PageItemsControl : ItemsControl
 {
-    private const double _zoomFactor = 1.1;
-
     /// <summary>
     /// The default value for the <see cref="PageItemsControl.ItemsPanel"/> property.
     /// </summary>
@@ -71,9 +68,14 @@ public sealed class PageItemsControl : ItemsControl
     private bool _isMultipleClickSelection;
 
     private Point? _startPointerPressed;
-    private Point? _currentPosition;
+
+    /// <summary>
+    /// Handles ctrl+wheel/pinch/external zoom and drag panning, owning the
+    /// in-flight zoom/pan state.
+    /// </summary>
+    private readonly ZoomPanController _zoomPanController;
+
     private bool _isSettingPageVisibility;
-    private bool _isZooming;
     private bool _pendingScrollToPage;
     private bool _isApplyingPendingScroll;
     private bool _isUpdatePagesVisibilityScheduled;
@@ -190,6 +192,7 @@ public sealed class PageItemsControl : ItemsControl
 
     public PageItemsControl()
     {
+        _zoomPanController = new ZoomPanController(this);
         _scrollChangedHandler = (_, e) =>
         {
             AdjustXOffsetOnExtentChanged(e);
@@ -200,7 +203,7 @@ public sealed class PageItemsControl : ItemsControl
         // Use a Tunnel handler to ensure zoom checks run before bubble-phase handlers
         // and avoid unwanted event scrolls by 50px before we can reject them.
         // No need to RemoveHandler() as it is on 'this', so it's GC'd with the control.
-        AddHandler(PointerWheelChangedEvent, OnPointerWheelChangedHandler, RoutingStrategies.Tunnel);
+        AddHandler(PointerWheelChangedEvent, _zoomPanController.OnPointerWheelChanged, RoutingStrategies.Tunnel);
         AddHandler(KeyDownEvent, OnKeyDownHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
         AddHandler(KeyUpEvent, OnKeyUpHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
 
@@ -1198,16 +1201,16 @@ public sealed class PageItemsControl : ItemsControl
         Scroll.Focus(); // Make sure the Scroll has focus
 
         LayoutTransform = e.NameScope.FindFromNameScope<LayoutTransformControl>("PART_LayoutTransformControl");
-        LayoutTransform.AddHandler(PointerPressedEvent, OnPointerPressed);
-        LayoutTransform.AddHandler(PointerMovedEvent, OnPointerMoved);
-        LayoutTransform.AddHandler(PointerReleasedEvent, OnPointerReleased);
+        LayoutTransform.AddHandler(PointerPressedEvent, _zoomPanController.OnPointerPressed);
+        LayoutTransform.AddHandler(PointerMovedEvent, _zoomPanController.OnPointerMoved);
+        LayoutTransform.AddHandler(PointerReleasedEvent, _zoomPanController.OnPointerReleased);
 
         if (CalyExtensions.IsMobilePlatform())
         {
             LayoutTransform.GestureRecognizers.Add(new PinchGestureRecognizer());
-            LayoutTransform.AddHandler(PinchEvent, _onPinchChangedHandler);
-            LayoutTransform.AddHandler(PinchEndedEvent, _onPinchChangedHandler);
-            LayoutTransform.AddHandler(HoldingEvent, _onPinchChangedHandler);
+            LayoutTransform.AddHandler(PinchEvent, _zoomPanController.OnPinchChanged);
+            LayoutTransform.AddHandler(PinchEndedEvent, _zoomPanController.OnPinchEnded);
+            LayoutTransform.AddHandler(HoldingEvent, _zoomPanController.OnHolding);
         }
     }
 
@@ -1223,15 +1226,15 @@ public sealed class PageItemsControl : ItemsControl
 
         if (LayoutTransform is not null)
         {
-            LayoutTransform.RemoveHandler(PointerPressedEvent, OnPointerPressed);
-            LayoutTransform.RemoveHandler(PointerMovedEvent, OnPointerMoved);
-            LayoutTransform.RemoveHandler(PointerReleasedEvent, OnPointerReleased);
+            LayoutTransform.RemoveHandler(PointerPressedEvent, _zoomPanController.OnPointerPressed);
+            LayoutTransform.RemoveHandler(PointerMovedEvent, _zoomPanController.OnPointerMoved);
+            LayoutTransform.RemoveHandler(PointerReleasedEvent, _zoomPanController.OnPointerReleased);
 
             if (CalyExtensions.IsMobilePlatform())
             {
-                LayoutTransform.RemoveHandler(PinchEvent, _onPinchChangedHandler);
-                LayoutTransform.RemoveHandler(PinchEndedEvent, _onPinchChangedHandler);
-                LayoutTransform.RemoveHandler(HoldingEvent, _onPinchChangedHandler);
+                LayoutTransform.RemoveHandler(PinchEvent, _zoomPanController.OnPinchChanged);
+                LayoutTransform.RemoveHandler(PinchEndedEvent, _zoomPanController.OnPinchEnded);
+                LayoutTransform.RemoveHandler(HoldingEvent, _zoomPanController.OnHolding);
             }
         }
     }
@@ -1321,6 +1324,10 @@ public sealed class PageItemsControl : ItemsControl
             ItemsPanelRoot?.LayoutUpdated -= ItemsPanelRoot_LayoutUpdated;
             ItemsPanelRoot?.LayoutUpdated += ItemsPanelRoot_LayoutUpdated;
         }
+        else if (change.Property == ZoomLevelProperty)
+        {
+            _zoomPanController.HandleExternalZoomLevelChanged(change);
+        }
     }
 
     private void EnsureValidContainersVisibility()
@@ -1371,7 +1378,8 @@ public sealed class PageItemsControl : ItemsControl
 
     private void AdjustXOffsetOnExtentChanged(ScrollChangedEventArgs e)
     {
-        if (Scroll is null || _suppressScrollAdjustment || _isZooming || _isPinching || _pendingScrollToPage)
+        if (Scroll is null || _suppressScrollAdjustment || _zoomPanController.IsZooming ||
+            _zoomPanController.IsPinching || _pendingScrollToPage)
         {
             return;
         }
@@ -1669,7 +1677,7 @@ public sealed class PageItemsControl : ItemsControl
     {
         if (e.IsPanningOrZooming())
         {
-            ResetPanTo();
+            _zoomPanController.ResetPan();
         }
     }
 
@@ -1682,7 +1690,7 @@ public sealed class PageItemsControl : ItemsControl
 
         if (e.IsPanningOrZooming())
         {
-            ResetPanTo();
+            _zoomPanController.ResetPan();
             return;
         }
 
@@ -1749,270 +1757,16 @@ public sealed class PageItemsControl : ItemsControl
         }
     }
 
-    #region Mobile handling
-
-    private void _onHoldingChangedHandler(object? sender, HoldingRoutedEventArgs e)
-    {
-        System.Diagnostics.Debug.WriteLine($"Holding {e.HoldingState}: {e.Position.X}, {e.Position.Y}");
-    }
-
-    private double _pinchZoomReference = 1.0;
-    private bool _isPinching;
-
-    private void _onPinchEndedHandler(object? sender, PinchEndedEventArgs e)
-    {
-        _pinchZoomReference = ZoomLevel;
-        _isPinching = false;
-    }
-
-    private void _onPinchChangedHandler(object? sender, PinchEventArgs e)
-    {
-        if (!_isPinching)
-        {
-            // Capture the zoom level at the start of each new pinch gesture so the
-            // first event doesn't compute dZoom against a stale reference of 1.0.
-            _pinchZoomReference = ZoomLevel;
-            _isPinching = true;
-        }
-
-        if (e.Scale != 0)
-        {
-            ZoomTo(e);
-            e.Handled = true;
-        }
-    }
-
-    private void ZoomTo(PinchEventArgs e)
-    {
-        if (LayoutTransform is null)
-        {
-            return;
-        }
-
-        if (_isZooming)
-        {
-            return;
-        }
-
-        try
-        {
-            _isZooming = true;
-
-            // Pinch zoom always starts with a scale of 1, then increase/decrease until PinchEnded
-            double dZoom = (e.Scale * _pinchZoomReference) / ZoomLevel;
-
-            // TODO - Origin still not correct
-            var point = LayoutTransform.PointToClient(new PixelPoint((int)e.ScaleOrigin.X, (int)e.ScaleOrigin.Y));
-            ZoomToInternal(dZoom, point);
-            SetCurrentValue(ZoomLevelProperty, LayoutTransform.LayoutTransform?.Value.M11);
-        }
-        finally
-        {
-            SetZoomFinished();
-        }
-    }
-    #endregion
-
-    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (!e.IsPanning())
-        {
-            return;
-        }
-
-        var point = e.GetCurrentPoint(this);
-        _currentPosition = point.Position;
-        e.Handled = true;
-    }
-
-    private void OnPointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (!e.IsPanningOrZooming())
-        {
-            return;
-        }
-
-        if (e.IsPanning())
-        {
-            SetPanCursor();
-            PanTo(e);
-        }
-
-        e.Handled = true;
-    }
-
-    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        ResetPanTo();
-    }
-
-    private void PanTo(PointerEventArgs e)
-    {
-        if (Scroll is null)
-        {
-            return;
-        }
-
-        var point = e.GetCurrentPoint(this);
-
-        if (!_currentPosition.HasValue)
-        {
-            _currentPosition = point.Position;
-            return;
-        }
-
-        var delta = point.Position - _currentPosition;
-
-        var offset = Scroll.Offset - delta.Value;
-        Scroll.SetCurrentValue(ScrollViewer.OffsetProperty, offset);
-        _currentPosition = point.Position;
-    }
-
-    private void ResetPanTo()
-    {
-        _currentPosition = null;
-        SetDefaultCursor();
-    }
-
-    private void OnPointerWheelChangedHandler(object? sender, PointerWheelEventArgs e)
-    {
-        var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
-        var ctrl = hotkeys is not null && e.KeyModifiers.HasFlag(hotkeys.CommandModifiers);
-
-        if (ctrl && e.Delta.Y != 0)
-        {
-            ZoomTo(e);
-            e.Handled = true;
-            e.PreventGestureRecognition();
-        }
-    }
-
-    private void ZoomTo(PointerWheelEventArgs e)
-    {
-        if (LayoutTransform is null)
-        {
-            return;
-        }
-
-        if (_isZooming)
-        {
-            return;
-        }
-
-        try
-        {
-            _isZooming = true;
-            double dZoom = Math.Round(Math.Pow(_zoomFactor, e.Delta.Y), 4); // If IsScrollInertiaEnabled = false, Y is only 1 or -1
-            ZoomToInternal(dZoom, e.GetPosition(LayoutTransform));
-            SetCurrentValue(ZoomLevelProperty, LayoutTransform.LayoutTransform?.Value.M11);
-        }
-        finally
-        {
-            SetZoomFinished();
-        }
-    }
-
-    internal void ZoomTo(double dZoom, Point point)
-    {
-        if (LayoutTransform is null || Scroll is null)
-        {
-            return;
-        }
-
-        if (_isZooming)
-        {
-            return;
-        }
-
-        try
-        {
-            _isZooming = true;
-            ZoomToInternal(dZoom, point);
-        }
-        finally
-        {
-            SetZoomFinished();
-        }
-    }
-
-    private void SetZoomFinished()
-    {
-        // ZoomToInternal positions the offset around the zoom origin itself, so
-        // suppress the auto-anchor in AdjustXOffsetOnExtentChanged for the layout/
-        // scroll events this transform change is about to produce. Setting to 'false'
-        // is posted at Loaded priority so it runs after the layout pass that
-        // updates Scroll.Extent.
-        //_isZooming = false;
-        Dispatcher.UIThread.Post(() =>
-        {
-            _isZooming = false;
-        }, DispatcherPriority.Loaded);
-    }
-
-    private void ZoomToInternal(double dZoom, Point point)
-    {
-        if (LayoutTransform is null || Scroll is null)
-        {
-            return;
-        }
-
-        double oldZoom = LayoutTransform.LayoutTransform?.Value.M11 ?? 1.0;
-        double newZoom = oldZoom * dZoom;
-
-        if (newZoom < MinZoomLevel)
-        {
-            if (oldZoom.Equals(MinZoomLevel))
-            {
-                return;
-            }
-
-            newZoom = MinZoomLevel;
-            dZoom = newZoom / oldZoom;
-        }
-        else if (newZoom > MaxZoomLevel)
-        {
-            if (oldZoom.Equals(MaxZoomLevel))
-            {
-                return;
-            }
-
-            newZoom = MaxZoomLevel;
-            dZoom = newZoom / oldZoom;
-        }
-
-        var builder = TransformOperations.CreateBuilder(1);
-        builder.AppendScale(newZoom, newZoom);
-        LayoutTransform.LayoutTransform = builder.Build();
-
-        var offset = Scroll.Offset - GetOffset(dZoom, point.X, point.Y);
-        if (newZoom > oldZoom)
-        {
-            // When zooming-in, we need to re-arrange the scroll viewer
-            Scroll.Measure(Size.Infinity);
-            Scroll.Arrange(new Rect(Scroll.DesiredSize));
-        }
-
-        Scroll.SetCurrentValue(ScrollViewer.OffsetProperty, offset);
-    }
-
-    private static Vector GetOffset(double scale, double x, double y)
-    {
-        double s = 1 - scale;
-        return new Vector(x * s, y * s);
-    }
-
     private void ResetState()
     {
         SetCurrentValue(VisiblePagesProperty, null);
-        _currentPosition = null;
         _isSelecting = false;
         _isMultipleClickSelection = false;
         _startPointerPressed = null;
+        _zoomPanController.Reset();
         _isSettingPageVisibility = false;
-        _isZooming = false;
         _pendingScrollToPage = false;
         _isApplyingPendingScroll = false;
-        _isPinching = false;
         _isUpdatePagesVisibilityScheduled = false;
         _suppressScrollAdjustment = false;
     }

--- a/Caly.Core/Controls/ZoomPanController.cs
+++ b/Caly.Core/Controls/ZoomPanController.cs
@@ -1,0 +1,377 @@
+// Copyright (c) 2025 BobLd
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media.Transformation;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Caly.Core.Utilities;
+
+namespace Caly.Core.Controls;
+
+/// <summary>
+/// Handles zooming (ctrl+wheel, pinch, and external <see cref="PageItemsControl.ZoomLevel"/>
+/// changes) and drag-panning on behalf of <see cref="PageItemsControl"/>, owning the
+/// in-flight interaction state (<see cref="IsZooming"/>, <see cref="IsPinching"/>, the
+/// pan position and the pinch zoom reference).
+/// </summary>
+internal sealed class ZoomPanController
+{
+    private const double ZoomFactor = 1.1;
+
+    private readonly PageItemsControl _owner;
+
+    private Point? _currentPosition;
+    private double _pinchZoomReference = 1.0;
+
+    public ZoomPanController(PageItemsControl owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner, nameof(owner));
+        _owner = owner;
+    }
+
+    /// <summary>
+    /// <c>true</c> while a zoom transform change is in flight, including the layout
+    /// pass it produces (cleared at Loaded priority, see <see cref="SetZoomFinished"/>).
+    /// </summary>
+    public bool IsZooming { get; private set; }
+
+    public bool IsPinching { get; private set; }
+
+    /// <summary>
+    /// Clears the in-flight interaction state, e.g. when the owner's DataContext changes.
+    /// </summary>
+    public void Reset()
+    {
+        _currentPosition = null;
+        IsZooming = false;
+        IsPinching = false;
+    }
+
+    #region Zoom
+
+    /// <summary>
+    /// Applies a <see cref="PageItemsControl.ZoomLevel"/> change that did not originate
+    /// from this controller's own zoom handlers (e.g. the view model's zoom in/out
+    /// commands), zooming around the viewport centre. Changes produced by the
+    /// wheel/pinch/programmatic handlers have already updated the layout transform, so
+    /// the scale comparison below turns them into no-ops.
+    /// </summary>
+    public void HandleExternalZoomLevelChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        var layoutTransform = _owner.LayoutTransform;
+        if (layoutTransform is null || change.NewValue is not double newZoom)
+        {
+            return;
+        }
+
+        if (!layoutTransform.IsAttachedToVisualTree())
+        {
+            return;
+        }
+
+        var currentScale = layoutTransform.LayoutTransform?.Value.M11;
+        if (currentScale.HasValue && Math.Abs(currentScale.Value - newZoom) < 1e-9)
+        {
+            return; // Ignore as no change in zoom level
+        }
+
+        double dZoom = newZoom / (double?)change.OldValue ?? 1.0;
+
+        double w = 0, h = 0;
+        if (!_owner.DesiredSize.IsEmpty())
+        {
+            _owner.DesiredSize.Deconstruct(out w, out h);
+        }
+        else if (!_owner.Bounds.Size.IsEmpty())
+        {
+            _owner.Bounds.Size.Deconstruct(out w, out h);
+        }
+
+        var pixelPoint = _owner.PointToScreen(new Point((int)(w / 2.0), (int)(h / 2.0)));
+        var point = layoutTransform.PointToClient(pixelPoint);
+        ZoomTo(dZoom, point);
+    }
+
+    /// <summary>
+    /// Tunnel handler for ctrl+wheel zooming, subscribed on the owner.
+    /// </summary>
+    public void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
+        var ctrl = hotkeys is not null && e.KeyModifiers.HasFlag(hotkeys.CommandModifiers);
+
+        if (ctrl && e.Delta.Y != 0)
+        {
+            ZoomTo(e);
+            e.Handled = true;
+            e.PreventGestureRecognition();
+        }
+    }
+
+    private void ZoomTo(PointerWheelEventArgs e)
+    {
+        if (_owner.LayoutTransform is null)
+        {
+            return;
+        }
+
+        if (IsZooming)
+        {
+            return;
+        }
+
+        try
+        {
+            IsZooming = true;
+            double dZoom = Math.Round(Math.Pow(ZoomFactor, e.Delta.Y), 4); // If IsScrollInertiaEnabled = false, Y is only 1 or -1
+            ZoomToInternal(dZoom, e.GetPosition(_owner.LayoutTransform));
+            _owner.SetCurrentValue(PageItemsControl.ZoomLevelProperty, _owner.LayoutTransform.LayoutTransform?.Value.M11);
+        }
+        finally
+        {
+            SetZoomFinished();
+        }
+    }
+
+    private void ZoomTo(double dZoom, Point point)
+    {
+        if (_owner.LayoutTransform is null || _owner.Scroll is null)
+        {
+            return;
+        }
+
+        if (IsZooming)
+        {
+            return;
+        }
+
+        try
+        {
+            IsZooming = true;
+            ZoomToInternal(dZoom, point);
+        }
+        finally
+        {
+            SetZoomFinished();
+        }
+    }
+
+    private void SetZoomFinished()
+    {
+        // ZoomToInternal positions the offset around the zoom origin itself, so
+        // suppress the auto-anchor in AdjustXOffsetOnExtentChanged for the layout/
+        // scroll events this transform change is about to produce. Setting to 'false'
+        // is posted at Loaded priority so it runs after the layout pass that
+        // updates Scroll.Extent.
+        //_isZooming = false;
+        Dispatcher.UIThread.Post(() =>
+        {
+            IsZooming = false;
+        }, DispatcherPriority.Loaded);
+    }
+
+    private void ZoomToInternal(double dZoom, Point point)
+    {
+        var layoutTransform = _owner.LayoutTransform;
+        var scroll = _owner.Scroll;
+        if (layoutTransform is null || scroll is null)
+        {
+            return;
+        }
+
+        double oldZoom = layoutTransform.LayoutTransform?.Value.M11 ?? 1.0;
+        double newZoom = oldZoom * dZoom;
+
+        if (newZoom < _owner.MinZoomLevel)
+        {
+            if (oldZoom.Equals(_owner.MinZoomLevel))
+            {
+                return;
+            }
+
+            newZoom = _owner.MinZoomLevel;
+            dZoom = newZoom / oldZoom;
+        }
+        else if (newZoom > _owner.MaxZoomLevel)
+        {
+            if (oldZoom.Equals(_owner.MaxZoomLevel))
+            {
+                return;
+            }
+
+            newZoom = _owner.MaxZoomLevel;
+            dZoom = newZoom / oldZoom;
+        }
+
+        var builder = TransformOperations.CreateBuilder(1);
+        builder.AppendScale(newZoom, newZoom);
+        layoutTransform.LayoutTransform = builder.Build();
+
+        var offset = scroll.Offset - GetOffset(dZoom, point.X, point.Y);
+        if (newZoom > oldZoom)
+        {
+            // When zooming-in, we need to re-arrange the scroll viewer
+            scroll.Measure(Size.Infinity);
+            scroll.Arrange(new Rect(scroll.DesiredSize));
+        }
+
+        scroll.SetCurrentValue(ScrollViewer.OffsetProperty, offset);
+    }
+
+    private static Vector GetOffset(double scale, double x, double y)
+    {
+        double s = 1 - scale;
+        return new Vector(x * s, y * s);
+    }
+
+    #endregion
+
+    #region Mobile handling
+
+    public void OnHolding(object? sender, HoldingRoutedEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine($"Holding {e.HoldingState}: {e.Position.X}, {e.Position.Y}");
+    }
+
+    public void OnPinchEnded(object? sender, PinchEndedEventArgs e)
+    {
+        _pinchZoomReference = _owner.ZoomLevel;
+        IsPinching = false;
+    }
+
+    public void OnPinchChanged(object? sender, PinchEventArgs e)
+    {
+        if (!IsPinching)
+        {
+            // Capture the zoom level at the start of each new pinch gesture so the
+            // first event doesn't compute dZoom against a stale reference of 1.0.
+            _pinchZoomReference = _owner.ZoomLevel;
+            IsPinching = true;
+        }
+
+        if (e.Scale != 0)
+        {
+            ZoomTo(e);
+            e.Handled = true;
+        }
+    }
+
+    private void ZoomTo(PinchEventArgs e)
+    {
+        if (_owner.LayoutTransform is null)
+        {
+            return;
+        }
+
+        if (IsZooming)
+        {
+            return;
+        }
+
+        try
+        {
+            IsZooming = true;
+
+            // Pinch zoom always starts with a scale of 1, then increase/decrease until PinchEnded
+            double dZoom = (e.Scale * _pinchZoomReference) / _owner.ZoomLevel;
+
+            // TODO - Origin still not correct
+            var point = _owner.LayoutTransform.PointToClient(new PixelPoint((int)e.ScaleOrigin.X, (int)e.ScaleOrigin.Y));
+            ZoomToInternal(dZoom, point);
+            _owner.SetCurrentValue(PageItemsControl.ZoomLevelProperty, _owner.LayoutTransform.LayoutTransform?.Value.M11);
+        }
+        finally
+        {
+            SetZoomFinished();
+        }
+    }
+
+    #endregion
+
+    #region Pan
+
+    public void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.IsPanning())
+        {
+            return;
+        }
+
+        var point = e.GetCurrentPoint(_owner);
+        _currentPosition = point.Position;
+        e.Handled = true;
+    }
+
+    public void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!e.IsPanningOrZooming())
+        {
+            return;
+        }
+
+        if (e.IsPanning())
+        {
+            _owner.SetPanCursor();
+            PanTo(e);
+        }
+
+        e.Handled = true;
+    }
+
+    public void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        ResetPan();
+    }
+
+    public void ResetPan()
+    {
+        _currentPosition = null;
+        _owner.SetDefaultCursor();
+    }
+
+    private void PanTo(PointerEventArgs e)
+    {
+        var scroll = _owner.Scroll;
+        if (scroll is null)
+        {
+            return;
+        }
+
+        var point = e.GetCurrentPoint(_owner);
+
+        if (!_currentPosition.HasValue)
+        {
+            _currentPosition = point.Position;
+            return;
+        }
+
+        var delta = point.Position - _currentPosition;
+
+        var offset = scroll.Offset - delta.Value;
+        scroll.SetCurrentValue(ScrollViewer.OffsetProperty, offset);
+        _currentPosition = point.Position;
+    }
+
+    #endregion
+}

--- a/Caly.Core/ViewModels/DocumentViewModel.cs
+++ b/Caly.Core/ViewModels/DocumentViewModel.cs
@@ -28,7 +28,6 @@ using Caly.Core.Services;
 using Caly.Core.Services.Interfaces;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -566,11 +565,5 @@ public sealed partial class DocumentViewModel : ViewModelBase
         await _pdfPageService.CancelAndClear().ConfigureAwait(false);
 
         GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, false);
-    }
-
-    [RelayCommand]
-    private void Activated()
-    {
-        App.Messenger.Send(new SelectedDocumentChangedMessage(this));
     }
 }

--- a/Caly.Core/ViewModels/MainViewModel.cs
+++ b/Caly.Core/ViewModels/MainViewModel.cs
@@ -20,6 +20,7 @@
 
 using Avalonia.Collections;
 using Caly.Core.Models;
+using Caly.Core.Services;
 using Caly.Core.Services.Interfaces;
 using Caly.Core.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -34,6 +35,7 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Messaging;
 using Tabalonia.Controls;
 
 namespace Caly.Core.ViewModels;
@@ -67,19 +69,62 @@ public sealed partial class MainViewModel : ViewModelBase, IDisposable
     {
         get
         {
-            try
-            {
-                return (SelectedDocumentIndex < 0 || PdfDocuments.Count == 0) ? null : PdfDocuments[SelectedDocumentIndex];
-            }
-            catch (Exception e)
-            {
-                Debug.WriteExceptionToFile(e);
-                return null;
-            }
+            int index = SelectedDocumentIndex;
+            return index >= 0 && index < PdfDocuments.Count ? PdfDocuments[index] : null;
         }
     }
 
     public string Version => CalyExtensions.CalyVersion;
+
+    /// <summary>
+    /// The document the last <see cref="SelectedDocumentChangedMessage"/> was sent for,
+    /// so switching between index/collection updates that resolve to the same document
+    /// does not re-announce it.
+    /// </summary>
+    private DocumentViewModel? _lastAnnouncedSelectedDocument;
+
+    private bool _isAnnounceSelectedDocumentScheduled;
+
+    partial void OnSelectedDocumentIndexChanged(int value)
+    {
+        ScheduleSelectedDocumentChanged();
+    }
+
+    /// <summary>
+    /// Schedules a single <see cref="SelectedDocumentChangedMessage"/> on the UI thread.
+    /// </summary>
+    private void ScheduleSelectedDocumentChanged()
+    {
+        /*
+         * Index and collection changes come in non-atomic bursts (e.g.  PdfDocumentsManagerService
+         * removes a document and only then corrects SelectedDocumentIndex; Tabalonia reorders tabs
+         * with Remove + Add), so announcing synchronously would observe transient states and
+         * activate the wrong document. Deferring to a posted callback coalesces the burst and runs
+         * once the state is settled.
+         */
+        if (_isAnnounceSelectedDocumentScheduled)
+        {
+            return;
+        }
+
+        _isAnnounceSelectedDocumentScheduled = true;
+        Dispatcher.UIThread.Post(() =>
+        {
+            _isAnnounceSelectedDocumentScheduled = false;
+            DocumentViewModel? selected = SelectedDocument;
+            if (ReferenceEquals(_lastAnnouncedSelectedDocument, selected))
+            {
+                return;
+            }
+
+            _lastAnnouncedSelectedDocument = selected;
+            if (selected is not null)
+            {
+                App.Messenger.Send(new SelectedDocumentChangedMessage(selected));
+            }
+        });
+    }
+
 
     partial void OnPaneSizeChanged(double oldValue, double newValue)
     {
@@ -89,6 +134,10 @@ public sealed partial class MainViewModel : ViewModelBase, IDisposable
 
     public MainViewModel()
     {
+        // Documents are added/removed on the UI thread; the selected document can
+        // change on collection changes without SelectedDocumentIndex changing.
+        PdfDocuments.CollectionChanged += (_, _) => ScheduleSelectedDocumentChanged();
+
         _documentCollectionDisposable = PdfDocuments
             .GetWeakCollectionChangedObservable()
             .ObserveOn(Scheduler.Default)


### PR DESCRIPTION
- Bind document state directly to the ViewModel in PageItemsControl's theme and move the zoom-around-centre reaction there.
- Replace the DocumentChanged command-property hack with MainViewModel sending SelectedDocumentChangedMessage when the selected document actually changes.
- Move ctrl+wheel/pinch/external zoom and drag-pan handling with their in-flight state into a dedicated collaborator.