### PR TITLE
Extract shared VirtualizedVisibilityTracker from the pages and thumbnails controls

### DIFF
--- a/Caly.Core/Controls/PageItemsControl.axaml.cs
+++ b/Caly.Core/Controls/PageItemsControl.axaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 BobLd
+// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,11 +32,14 @@ using Caly.Core.Utilities;
 using Caly.Pdf;
 using Caly.Pdf.Models;
 using System;
-using System.Linq;
 using System.Windows.Input;
 using Avalonia.Threading;
 using UglyToad.PdfPig.Actions;
 using UglyToad.PdfPig.Core;
+
+#if DEBUG
+using System.Linq;
+#endif
 
 namespace Caly.Core.Controls;
 
@@ -75,10 +78,15 @@ public sealed class PageItemsControl : ItemsControl
     /// </summary>
     private readonly ZoomPanController _zoomPanController;
 
+    /// <summary>
+    /// Shared visibility-tracking machinery (debounced updates, realized-range
+    /// queries, container-visibility workaround).
+    /// </summary>
+    private readonly VirtualizedVisibilityTracker _visibilityTracker;
+
     private bool _isSettingPageVisibility;
     private bool _pendingScrollToPage;
     private bool _isApplyingPendingScroll;
-    private bool _isUpdatePagesVisibilityScheduled;
 
     private readonly EventHandler<ScrollChangedEventArgs> _scrollChangedHandler;
     private readonly EventHandler<SizeChangedEventArgs> _sizeChangedHandler;
@@ -193,12 +201,13 @@ public sealed class PageItemsControl : ItemsControl
     public PageItemsControl()
     {
         _zoomPanController = new ZoomPanController(this);
+        _visibilityTracker = new VirtualizedVisibilityTracker(this, () => UpdatePagesVisibility());
         _scrollChangedHandler = (_, e) =>
         {
             AdjustXOffsetOnExtentChanged(e);
-            PostUpdatePagesVisibility();
+            _visibilityTracker.PostUpdateVisibility();
         };
-        _sizeChangedHandler = (_, _) => PostUpdatePagesVisibility();
+        _sizeChangedHandler = (_, _) => _visibilityTracker.PostUpdateVisibility();
 
         // Use a Tunnel handler to ensure zoom checks run before bubble-phase handlers
         // and avoid unwanted event scrolls by 50px before we can reject them.
@@ -1063,37 +1072,6 @@ public sealed class PageItemsControl : ItemsControl
         return NeedsContainer<PageItem>(item, out recycleKey);
     }
 
-    /// <summary>
-    /// Starts at 0. Inclusive.
-    /// </summary>
-    private int GetMinPageIndex()
-    {
-        if (ItemsPanelRoot is VirtualizingStackPanel v)
-        {
-            return v.FirstRealizedIndex;
-        }
-        return 0;
-    }
-
-    /// <summary>
-    /// Starts at 0. Exclusive.
-    /// <para>-1 if not realised.</para>
-    /// </summary>
-    private int GetMaxPageIndex()
-    {
-        if (ItemsPanelRoot is VirtualizingStackPanel v)
-        {
-            if (v.LastRealizedIndex == -1)
-            {
-                return -1;
-            }
-
-            return Math.Min(PageCount, v.LastRealizedIndex + 1);
-        }
-
-        return PageCount;
-    }
-
     public PageItem? GetPageItemOver(PointerEventArgs e)
     {
         if (Presenter is null)
@@ -1110,8 +1088,8 @@ public sealed class PageItemsControl : ItemsControl
             return null;
         }
 
-        int minPageIndex = GetMinPageIndex();
-        int maxPageIndex = GetMaxPageIndex(); // Exclusive
+        int minPageIndex = _visibilityTracker.GetFirstRealizedIndex();
+        int maxPageIndex = _visibilityTracker.GetLastRealizedIndex();
 
         if (minPageIndex == -1 || maxPageIndex == -1)
         {
@@ -1268,7 +1246,7 @@ public sealed class PageItemsControl : ItemsControl
             return;
         }
 
-        if (GetMaxPageIndex() > 0)
+        if (_visibilityTracker.GetLastRealizedIndex() > 0)
         {
             if (_pendingScrollToPage)
             {
@@ -1320,32 +1298,13 @@ public sealed class PageItemsControl : ItemsControl
             ResetState();
             _pendingScrollToPage = true;
             Scroll?.Focus();
-            EnsureValidContainersVisibility();
+            _visibilityTracker.EnsureValidContainersVisibility();
             ItemsPanelRoot?.LayoutUpdated -= ItemsPanelRoot_LayoutUpdated;
             ItemsPanelRoot?.LayoutUpdated += ItemsPanelRoot_LayoutUpdated;
         }
         else if (change.Property == ZoomLevelProperty)
         {
             _zoomPanController.HandleExternalZoomLevelChanged(change);
-        }
-    }
-
-    private void EnsureValidContainersVisibility()
-    {
-        // This is a hack to ensure only valid containers (realised) are visible
-        // See https://github.com/CalyPdf/Caly/issues/11
-
-        if (ItemsPanelRoot is null)
-        {
-            return;
-        }
-
-        var realised = GetRealizedContainers().OfType<PageItem>();
-        var visibleChildren = ItemsPanelRoot.Children.Where(c => c.IsVisible).OfType<PageItem>();
-
-        foreach (var child in visibleChildren.Except(realised))
-        {
-            child.SetCurrentValue(IsVisibleProperty, false);
         }
     }
 
@@ -1361,17 +1320,7 @@ public sealed class PageItemsControl : ItemsControl
         // Ensure the pages visibility is set when OnApplyTemplate()
         // is not called, i.e. when a new document is opened but the
         // page has exactly the same dimension of the visible page
-        PostUpdatePagesVisibility();
-    }
-
-    private bool HasRealisedItems()
-    {
-        if (ItemsPanelRoot is VirtualizingStackPanel vsp)
-        {
-            return vsp.FirstRealizedIndex != -1 && vsp.LastRealizedIndex != -1;
-        }
-
-        return false;
+        _visibilityTracker.PostUpdateVisibility();
     }
 
     private bool _suppressScrollAdjustment;
@@ -1440,21 +1389,6 @@ public sealed class PageItemsControl : ItemsControl
         }
     }
 
-    private void PostUpdatePagesVisibility()
-    {
-        if (_isUpdatePagesVisibilityScheduled)
-        {
-            return;
-        }
-
-        _isUpdatePagesVisibilityScheduled = true;
-        Dispatcher.UIThread.Post(() =>
-        {
-            _isUpdatePagesVisibilityScheduled = false;
-            UpdatePagesVisibility();
-        }, DispatcherPriority.Loaded);
-    }
-
     private bool UpdatePagesVisibility()
     {
         // Exit early if the view is unstable (e.g., user interacting, or a tab-switch
@@ -1465,7 +1399,7 @@ public sealed class PageItemsControl : ItemsControl
         }
 
         if (LayoutTransform is null || Scroll is null ||
-            Scroll.Viewport.IsEmpty() || ItemsView.Count == 0 || !HasRealisedItems())
+            Scroll.Viewport.IsEmpty() || ItemsView.Count == 0 || !_visibilityTracker.HasRealizedItems())
         {
             return false;
         }
@@ -1476,8 +1410,8 @@ public sealed class PageItemsControl : ItemsControl
         double invScale = 1.0 / (LayoutTransform.LayoutTransform?.Value.M11 ?? 1.0);
         Rect viewport = Scroll.GetViewportRect().TransformToAABB(Matrix.CreateScale(invScale, invScale));
 
-        int firstRealisedIndex = GetMinPageIndex();
-        int lastRealisedIndex = GetMaxPageIndex();
+        int firstRealisedIndex = _visibilityTracker.GetFirstRealizedIndex();
+        int lastRealisedIndex = _visibilityTracker.GetLastRealizedIndex();
 
         if (firstRealisedIndex == -1 || lastRealisedIndex == -1)
         {
@@ -1767,7 +1701,7 @@ public sealed class PageItemsControl : ItemsControl
         _isSettingPageVisibility = false;
         _pendingScrollToPage = false;
         _isApplyingPendingScroll = false;
-        _isUpdatePagesVisibilityScheduled = false;
+        _visibilityTracker.Reset();
         _suppressScrollAdjustment = false;
     }
 }

--- a/Caly.Core/Controls/ThumbnailItemsControl.cs
+++ b/Caly.Core/Controls/ThumbnailItemsControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,17 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
-using Avalonia.Threading;
 using Caly.Core.Utilities;
 using System;
-using System.Linq;
 using System.Windows.Input;
-using Avalonia.Controls.Presenters;
 
 namespace Caly.Core.Controls;
 
 public sealed class ThumbnailItemsControl : ListBox
 {
     private bool _isScrollingToPage;
-    private bool _isUpdateThumbnailsVisibilityScheduled;
+
+    private readonly VirtualizedVisibilityTracker _visibilityTracker;
 
     private ScrollViewer? _scrollViewer;
 
@@ -90,9 +88,10 @@ public sealed class ThumbnailItemsControl : ListBox
     
     public ThumbnailItemsControl()
     {
-        _scrollChangedHandler = (_, _) => PostUpdateThumbnailsVisibility();
-        _sizeChangedHandler = (_, _) => PostUpdateThumbnailsVisibility();
-        _loadedHandler = (_, _) => PostUpdateThumbnailsVisibility();
+        _visibilityTracker = new VirtualizedVisibilityTracker(this, () => UpdateThumbnailsVisibility());
+        _scrollChangedHandler = (_, _) => _visibilityTracker.PostUpdateVisibility();
+        _sizeChangedHandler = (_, _) => _visibilityTracker.PostUpdateVisibility();
+        _loadedHandler = (_, _) => _visibilityTracker.PostUpdateVisibility();
         ResetState();
     }
 
@@ -118,35 +117,16 @@ public sealed class ThumbnailItemsControl : ListBox
         }
     }
 
-    private void PostUpdateThumbnailsVisibility()
+    private void UpdateThumbnailsVisibility()
     {
-        if (_isUpdateThumbnailsVisibilityScheduled)
+        if (_scrollViewer is null || _isScrollingToPage)
         {
             return;
         }
 
-        _isUpdateThumbnailsVisibilityScheduled = true;
-        Dispatcher.UIThread.Post(() =>
-        {
-            _isUpdateThumbnailsVisibilityScheduled = false;
-            UpdateThumbnailsVisibility();
-        }, DispatcherPriority.Loaded);
-    }
 
-    private bool UpdateThumbnailsVisibility()
-    {
-        if (_scrollViewer is null)
-        {
-            return false;
-        }
-
-        if (_isScrollingToPage)
-        {
-            return false;
-        }
-
-        int firstRealisedIndex = GetMinPageIndex();
-        int lastRealisedIndex = GetMaxPageIndex();
+        int firstRealisedIndex = _visibilityTracker.GetFirstRealizedIndex();
+        int lastRealisedIndex = _visibilityTracker.GetLastRealizedIndex();
 
         if (firstRealisedIndex == -1 || lastRealisedIndex == -1)
         {
@@ -158,7 +138,7 @@ public sealed class ThumbnailItemsControl : ListBox
                 RefreshThumbnails?.Execute(null);
             }
             
-            return true;
+            return;
         }
 
         bool previousVisible = false;
@@ -211,40 +191,8 @@ public sealed class ThumbnailItemsControl : ListBox
             RefreshThumbnails?.Execute(null);
         }
 
-        return true;
+        return;
     }
-
-    /// <summary>
-    /// Starts at 0. Inclusive.
-    /// </summary>
-    private int GetMinPageIndex()
-    {
-        if (ItemsPanelRoot is VirtualizingStackPanel v)
-        {
-            return v.FirstRealizedIndex;
-        }
-        return 0;
-    }
-
-    /// <summary>
-    /// Starts at 0. Exclusive.
-    /// <para>-1 if not realised.</para>
-    /// </summary>
-    private int GetMaxPageIndex()
-    {
-        if (ItemsPanelRoot is VirtualizingStackPanel v)
-        {
-            if (v.LastRealizedIndex == -1)
-            {
-                return -1;
-            }
-            
-            return Math.Min(ItemCount, v.LastRealizedIndex + 1);
-        }
-
-        return ItemCount;
-    }
-    
 
     protected override void PrepareContainerForItemOverride(Control container, object? item, int index)
     {
@@ -255,7 +203,7 @@ public sealed class ThumbnailItemsControl : ListBox
             return;
         }
 
-        PostUpdateThumbnailsVisibility();
+        _visibilityTracker.PostUpdateVisibility();
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -265,7 +213,7 @@ public sealed class ThumbnailItemsControl : ListBox
         if (change.Property == DataContextProperty)
         {
             ResetState();
-            EnsureValidContainersVisibility();
+            _visibilityTracker.EnsureValidContainersVisibility();
         }
         else if (change.Property == IsVisibleProperty)
         {
@@ -281,8 +229,8 @@ public sealed class ThumbnailItemsControl : ListBox
                     _isScrollingToPage = false;
                 }
 
-                EnsureValidContainersVisibility();
-                PostUpdateThumbnailsVisibility();
+                _visibilityTracker.EnsureValidContainersVisibility();
+                _visibilityTracker.PostUpdateVisibility();
             }
             else if (change is { OldValue: true, NewValue: false })
             {
@@ -294,30 +242,11 @@ public sealed class ThumbnailItemsControl : ListBox
         }
     }
 
-    private void EnsureValidContainersVisibility()
-    {
-        // This is a hack to ensure only valid containers (realised) are visible
-        // See https://github.com/CalyPdf/Caly/issues/11
-
-        if (ItemsPanelRoot is null)
-        {
-            return;
-        }
-
-        var realised = GetRealizedContainers().OfType<ListBoxItem>();
-        var visibleChildren = ItemsPanelRoot.Children.Where(c => c.IsVisible).OfType<ListBoxItem>();
-
-        foreach (var child in visibleChildren.Except(realised))
-        {
-            child.SetCurrentValue(IsVisibleProperty, false);
-        }
-    }
-    
     private void ResetState()
     {
         SetCurrentValue(RealisedThumbnailsProperty, null);
         SetCurrentValue(VisibleThumbnailsProperty, null);
         _isScrollingToPage = false;
-        _isUpdateThumbnailsVisibilityScheduled = false;
+        _visibilityTracker.Reset();
     }
 }

--- a/Caly.Core/Controls/VirtualizedVisibilityTracker.cs
+++ b/Caly.Core/Controls/VirtualizedVisibilityTracker.cs
@@ -1,0 +1,140 @@
+// Copyright (c) BobLd
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace Caly.Core.Controls;
+
+/// <summary>
+/// Shared visibility-tracking machinery for the virtualized items controls
+/// (<see cref="PageItemsControl"/> and <see cref="ThumbnailItemsControl"/>):
+/// debounced visibility updates, realized-index range queries against the
+/// <see cref="VirtualizingStackPanel"/>, and the realized-containers visibility
+/// workaround for https://github.com/CalyPdf/Caly/issues/11.
+/// </summary>
+internal sealed class VirtualizedVisibilityTracker
+{
+    private readonly ItemsControl _owner;
+    private readonly Action _updateVisibility;
+
+    private bool _isUpdateScheduled;
+
+    /// <param name="owner">The virtualized items control being tracked.</param>
+    /// <param name="updateVisibility">The owner's visibility-update pass, invoked by
+    /// <see cref="PostUpdateVisibility"/> on the UI thread at Loaded priority.</param>
+    public VirtualizedVisibilityTracker(ItemsControl owner, Action updateVisibility)
+    {
+        ArgumentNullException.ThrowIfNull(owner, nameof(owner));
+        ArgumentNullException.ThrowIfNull(updateVisibility, nameof(updateVisibility));
+        _owner = owner;
+        _updateVisibility = updateVisibility;
+    }
+
+    /// <summary>
+    /// Schedules a visibility update on the UI thread at Loaded priority, coalescing
+    /// requests so bursts of scroll/size events produce a single update.
+    /// </summary>
+    public void PostUpdateVisibility()
+    {
+        if (_isUpdateScheduled)
+        {
+            return;
+        }
+
+        _isUpdateScheduled = true;
+        Dispatcher.UIThread.Post(() =>
+        {
+            _isUpdateScheduled = false;
+            _updateVisibility();
+        }, DispatcherPriority.Loaded);
+    }
+
+    /// <summary>
+    /// Clears the pending-update flag, e.g. when the owner's DataContext changes.
+    /// An already-queued update still runs.
+    /// </summary>
+    public void Reset()
+    {
+        _isUpdateScheduled = false;
+    }
+
+    /// <summary>
+    /// First realized item index. Starts at 0. Inclusive.
+    /// </summary>
+    public int GetFirstRealizedIndex()
+    {
+        if (_owner.ItemsPanelRoot is VirtualizingStackPanel v)
+        {
+            return v.FirstRealizedIndex;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Last realized item index. Starts at 0. Exclusive.
+    /// <para>-1 if none realized.</para>
+    /// </summary>
+    public int GetLastRealizedIndex()
+    {
+        if (_owner.ItemsPanelRoot is VirtualizingStackPanel v)
+        {
+            if (v.LastRealizedIndex == -1)
+            {
+                return -1;
+            }
+
+            return Math.Min(_owner.ItemCount, v.LastRealizedIndex + 1);
+        }
+
+        return _owner.ItemCount;
+    }
+
+    public bool HasRealizedItems()
+    {
+        return _owner.ItemsPanelRoot is VirtualizingStackPanel vsp &&
+               vsp.FirstRealizedIndex != -1 && vsp.LastRealizedIndex != -1;
+    }
+
+    /// <summary>
+    /// Hides panel children that are still visible but no longer realized.
+    /// This is a hack to ensure only valid containers (realised) are visible.
+    /// See https://github.com/CalyPdf/Caly/issues/11
+    /// </summary>
+    public void EnsureValidContainersVisibility()
+    {
+        if (_owner.ItemsPanelRoot is null)
+        {
+            return;
+        }
+
+        var realised = _owner.GetRealizedContainers();
+        var visibleChildren = _owner.ItemsPanelRoot.Children.Where(c => c.IsVisible);
+
+        foreach (var child in visibleChildren.Except(realised))
+        {
+            child.SetCurrentValue(Visual.IsVisibleProperty, false);
+        }
+    }
+}


### PR DESCRIPTION
Deduplicate the debounced visibility updates, realized-range queries, and the issue-#11 container-visibility workaround from PageItemsControl and ThumbnailItemsControl into a single collaborator so fixes apply to both controls.