### PR TITLE
Route page pointer input through PageItemsControl instead of per-container wiring

### DIFF
--- a/Caly.Core/Controls/PageItem.axaml.cs
+++ b/Caly.Core/Controls/PageItem.axaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 BobLd
+// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -136,9 +136,9 @@ public sealed class PageItem : ContentControl
     }
 
     /// <summary>
-    /// Gets the interactive layer.
+    /// Gets the interactive layer. Set in OnApplyTemplate.
     /// </summary>
-    public PageInteractiveLayerControl? InteractiveLayer { get; set; }
+    public PageInteractiveLayerControl? InteractiveLayer { get; private set; }
 
     public PageItem()
     {

--- a/Caly.Core/Controls/PageItemsControl.axaml.cs
+++ b/Caly.Core/Controls/PageItemsControl.axaml.cs
@@ -63,16 +63,16 @@ public sealed class PageItemsControl : ItemsControl
     private readonly TextSelectionInputHandler _textSelectionHandler;
 
     /// <summary>
-    /// Handles ctrl+wheel/pinch/external zoom and drag panning, owning the
-    /// in-flight zoom/pan state.
-    /// </summary>
-    private readonly ZoomPanController _zoomPanController;
-
-    /// <summary>
     /// Shared visibility-tracking machinery (debounced updates, realized-range
     /// queries, container-visibility workaround).
     /// </summary>
     private readonly VirtualizedVisibilityTracker _visibilityTracker;
+
+    /// <summary>
+    /// Handles ctrl+wheel/pinch/external zoom and drag panning, owning the
+    /// in-flight zoom/pan state.
+    /// </summary>
+    private readonly ZoomPanController _zoomPanController;
 
     private bool _isSettingPageVisibility;
     private bool _pendingScrollToPage;
@@ -191,8 +191,8 @@ public sealed class PageItemsControl : ItemsControl
     public PageItemsControl()
     {
         _textSelectionHandler = new TextSelectionInputHandler(this);
-        _zoomPanController = new ZoomPanController(this);
         _visibilityTracker = new VirtualizedVisibilityTracker(this, () => UpdatePagesVisibility());
+        _zoomPanController = new ZoomPanController(this);
         _scrollChangedHandler = (_, e) =>
         {
             AdjustXOffsetOnExtentChanged(e);
@@ -206,8 +206,36 @@ public sealed class PageItemsControl : ItemsControl
         AddHandler(PointerWheelChangedEvent, _zoomPanController.OnPointerWheelChanged, RoutingStrategies.Tunnel);
         AddHandler(KeyDownEvent, OnKeyDownHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
         AddHandler(KeyUpEvent, OnKeyUpHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
+        AddHandler(PointerPressedEvent, OnInteractiveLayerPointerPressed, RoutingStrategies.Tunnel);
+        AddHandler(PointerReleasedEvent, OnInteractiveLayerPointerReleased, RoutingStrategies.Tunnel);
+        AddHandler(PointerMovedEvent, OnInteractiveLayerPointerMoved, RoutingStrategies.Tunnel);
+        AddHandler(PointerWheelChangedEvent, OnInteractiveLayerPointerMoved, RoutingStrategies.Tunnel);
 
         ResetState();
+    }
+
+    private void OnInteractiveLayerPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is PageInteractiveLayerControl layer)
+        {
+            _textSelectionHandler.OnPointerPressed(layer, e);
+        }
+    }
+
+    private void OnInteractiveLayerPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (e.Source is PageInteractiveLayerControl layer)
+        {
+            _textSelectionHandler.OnPointerReleased(layer, e);
+        }
+    }
+
+    private void OnInteractiveLayerPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (e.Source is PageInteractiveLayerControl layer)
+        {
+            _textSelectionHandler.OnPointerMoved(layer, e);
+        }
     }
 
     /// <summary>
@@ -499,11 +527,7 @@ public sealed class PageItemsControl : ItemsControl
             return;
         }
 
-        pageItem.InteractiveLayer.PointerMoved -= _textSelectionHandler.OnPointerMoved;
-        pageItem.InteractiveLayer.PointerWheelChanged -= _textSelectionHandler.OnPointerMoved;
         pageItem.InteractiveLayer.PointerExited -= _textSelectionHandler.OnPointerExited;
-        pageItem.InteractiveLayer.PointerReleased -= _textSelectionHandler.OnPointerReleased;
-        pageItem.InteractiveLayer.PointerPressed -= _textSelectionHandler.OnPointerPressed;
         pageItem.BeforeRotation -= OnBeforePageRotation;
     }
 
@@ -521,20 +545,16 @@ public sealed class PageItemsControl : ItemsControl
             return;
         }
 
+        // Pressed/Released/Moved/Wheel are handled through routed tunnel handlers on
+        // this control (see the constructor); only PointerExited needs a per-container
+        // subscription as it does not route through ancestors.
+        
         // Make sure we unsubscribe first
-        pageItem.InteractiveLayer.PointerMoved -= _textSelectionHandler.OnPointerMoved;
-        pageItem.InteractiveLayer.PointerWheelChanged -= _textSelectionHandler.OnPointerMoved;
         pageItem.InteractiveLayer.PointerExited -= _textSelectionHandler.OnPointerExited;
-        pageItem.InteractiveLayer.PointerReleased -= _textSelectionHandler.OnPointerReleased;
-        pageItem.InteractiveLayer.PointerPressed -= _textSelectionHandler.OnPointerPressed;
         pageItem.BeforeRotation -= OnBeforePageRotation;
 
         // Then subscribe to events
-        pageItem.InteractiveLayer.PointerMoved += _textSelectionHandler.OnPointerMoved;
-        pageItem.InteractiveLayer.PointerWheelChanged += _textSelectionHandler.OnPointerMoved;
         pageItem.InteractiveLayer.PointerExited += _textSelectionHandler.OnPointerExited;
-        pageItem.InteractiveLayer.PointerReleased += _textSelectionHandler.OnPointerReleased;
-        pageItem.InteractiveLayer.PointerPressed += _textSelectionHandler.OnPointerPressed;
         pageItem.BeforeRotation += OnBeforePageRotation;
     }
 

--- a/Caly.Core/Controls/TextSelectionInputHandler.cs
+++ b/Caly.Core/Controls/TextSelectionInputHandler.cs
@@ -67,12 +67,12 @@ internal sealed class TextSelectionInputHandler
         _startPointerPressed = null;
     }
 
-    public void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    public void OnPointerPressed(PageInteractiveLayerControl control, PointerPressedEventArgs e)
     {
         Debug.ThrowNotOnUiThread();
 
         var textSelection = _owner.TextSelection;
-        if (textSelection is null || sender is not PageInteractiveLayerControl control || control.PdfTextLayer is null)
+        if (textSelection is null || control.PdfTextLayer is null)
         {
             return;
         }
@@ -154,11 +154,11 @@ internal sealed class TextSelectionInputHandler
         System.Diagnostics.Debug.WriteLine($"HandleMultipleClick: {startWord} -> {endWord}.");
     }
 
-    public void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    public void OnPointerReleased(PageInteractiveLayerControl control, PointerReleasedEventArgs e)
     {
         Debug.ThrowNotOnUiThread();
 
-        if (sender is not PageInteractiveLayerControl control || control.PdfTextLayer is null)
+        if (control.PdfTextLayer is null)
         {
             return;
         }
@@ -210,7 +210,15 @@ internal sealed class TextSelectionInputHandler
 
         _isSelecting = false;
 
-        e.Handled = true;
+        // Right-button releases must stay unhandled: this runs in the tunnel phase, and
+        // Control.OnPointerReleased on the layer only raises ContextRequested (which
+        // opens the page's ContextFlyout) for unhandled events. Opening the flyout
+        // marks the event handled right after, so the rest of the route is unaffected.
+        if (e.InitialPressMouseButton != MouseButton.Right)
+        {
+            e.Handled = true;
+        }
+
         e.PreventGestureRecognition();
     }
 
@@ -277,12 +285,12 @@ internal sealed class TextSelectionInputHandler
         _owner.SetCurrentValue(PageItemsControl.InteractiveActionOverProperty, null);
     }
 
-    public void OnPointerMoved(object? sender, PointerEventArgs e)
+    public void OnPointerMoved(PageInteractiveLayerControl control, PointerEventArgs e)
     {
         Debug.ThrowNotOnUiThread();
 
         // Needs to be on UI thread to access
-        if (sender is not PageInteractiveLayerControl control || control.PdfTextLayer is null)
+        if (control.PdfTextLayer is null)
         {
             return;
         }


### PR DESCRIPTION
Replace the per-layer pointer subscriptions in PageItem_Loaded/Unloaded with routed tunnel handlers on PageItemsControl that resolve the interactive layer from the event source, keeping only PointerExited and BeforeRotation per-container. Right-button releases now stay unhandled so Control.OnPointerReleased still raises ContextRequested and the page context flyout keeps opening.