### PR TITLE
Bind the page flyout's copy command through PageViewModel

### DIFF
--- a/Caly.Core/Controls/PageItem.axaml
+++ b/Caly.Core/Controls/PageItem.axaml
@@ -33,7 +33,7 @@
 		<Setter Property="ContextFlyout">
 			<MenuFlyout>
 				<MenuItem Header="{DynamicResource StringTextFlyoutCopyText}"
-                          Command="{Binding $parent[controls:PageItemsControl].((vm:DocumentViewModel)DataContext).CopyTextCommand}"
+                          Command="{Binding CopyTextCommand}"
                           InputGesture="{x:Static utilities:CalyHotkeyConfiguration.CopyGesture}"/>
 
 				<Separator/>

--- a/Caly.Core/ViewModels/DocumentViewModel.cs
+++ b/Caly.Core/ViewModels/DocumentViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -373,7 +373,7 @@ public sealed partial class DocumentViewModel : ViewModelBase
             System.Diagnostics.Debug.Assert(TextSelection is not null);
 
             // Use 1st page size as default page size
-            var firstPage = new PageViewModel(1, TextSelection, _pdfPageService.TileRenderService, _pdfService.PpiScale);
+            var firstPage = new PageViewModel(1, TextSelection, _pdfPageService.TileRenderService, _pdfService.PpiScale, CopyTextCommand);
             var pageSize = await _pdfPageService.GetPageSize(1, _mainToken).ConfigureAwait(false);
             if (pageSize.HasValue)
             {
@@ -388,7 +388,7 @@ public sealed partial class DocumentViewModel : ViewModelBase
             for (int p = 2; p <= PageCount; ++p)
             {
                 _mainToken.ThrowIfCancellationRequested();
-                var newPage = new PageViewModel(p, TextSelection, _pdfPageService.TileRenderService, _pdfService.PpiScale)
+                var newPage = new PageViewModel(p, TextSelection, _pdfPageService.TileRenderService, _pdfService.PpiScale, CopyTextCommand)
                 {
                     Size = defaultSize
                 };

--- a/Caly.Core/ViewModels/PageViewModel.cs
+++ b/Caly.Core/ViewModels/PageViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Windows.Input;
 using UglyToad.PdfPig.Core;
 
 namespace Caly.Core.ViewModels;
@@ -96,6 +97,13 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
     public double PpiScale { get; }
 
     public TileRenderService TileRenderService { get; }
+
+    /// <summary>
+    /// The owning document's copy-text command, exposed here so page-level views
+    /// (e.g. the page context flyout) can bind to it directly instead of reaching
+    /// up the visual tree for the document view model.
+    /// </summary>
+    public ICommand CopyTextCommand { get; }
 
     public bool IsPageVisible => VisibleArea.HasValue;
 
@@ -201,16 +209,20 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
 
         TextSelection = null!;
         TileRenderService = null!;
+        CopyTextCommand = null!;
     }
 #endif
-    
-    public PageViewModel(int pageNumber, TextSelection textSelection, TileRenderService tileRenderService, double ppiScale)
+
+    public PageViewModel(int pageNumber, TextSelection textSelection, TileRenderService tileRenderService,
+        double ppiScale, ICommand copyTextCommand)
     {
         ArgumentNullException.ThrowIfNull(textSelection, nameof(textSelection));
+        ArgumentNullException.ThrowIfNull(copyTextCommand, nameof(copyTextCommand));
         PageNumber = pageNumber;
         TileRenderService = tileRenderService;
         PpiScale = ppiScale;
         TextSelection = textSelection;
+        CopyTextCommand = copyTextCommand;
 
         // We don't unsubscribe from the TextSelection events as it takes
         // forever when the number of pages is large.


### PR DESCRIPTION
Pass the document's CopyTextCommand into PageViewModel at construction so the page context flyout uses a direct compiled binding instead of the fragile $parent[PageItemsControl] DataContext cast.