### PR TITLE
Tidy up and improve pane state, dispatcher posts, view-math converters

### DIFF
--- a/Caly.Core/App.axaml.cs
+++ b/Caly.Core/App.axaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Notifications;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Markup.Xaml;
@@ -87,12 +86,17 @@ public partial class App : Application
         // Initialise dependencies
         var services = new ServiceCollection();
 
+        // Single app-level states, shared between the MainViewModel (created before
+        // the service provider is built) and every DI-scoped DocumentViewModel.
+        var appStates = new ApplicationStates();
+        services.AddSingleton(appStates);
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainViewModel()
+                DataContext = new MainViewModel(appStates)
             };
 
             services.AddSingleton<Visual>(_ => desktop.MainWindow);
@@ -108,7 +112,7 @@ public partial class App : Application
             MainView? mainView = null;
             activityLifetime.MainViewFactory = () => mainView = new MainView
             {
-                DataContext = new MainViewModel()
+                DataContext = new MainViewModel(appStates)
             };
             services.AddSingleton<Visual>(_ => mainView ??
                 throw new InvalidOperationException("MainView has not been created yet."));
@@ -123,7 +127,7 @@ public partial class App : Application
         {
             singleViewPlatform.MainView = new MainView
             {
-                DataContext = new MainViewModel()
+                DataContext = new MainViewModel(appStates)
             };
             services.AddSingleton<Visual>(_ => singleViewPlatform.MainView);
             services.AddSingleton<IStorageProvider>(_ =>
@@ -136,7 +140,7 @@ public partial class App : Application
 #if DEBUG
         else if (ApplicationLifetime is null && Avalonia.Controls.Design.IsDesignMode)
         {
-            var mainView = new MainView { DataContext = new MainViewModel() };
+            var mainView = new MainView { DataContext = new MainViewModel(appStates) };
             services.AddSingleton<Visual>(_ => mainView);
             services.AddSingleton<IStorageProvider>(_ => TopLevel.GetTopLevel(mainView)?.StorageProvider);
             services.AddSingleton<IClipboard>(_ => TopLevel.GetTopLevel(mainView)?.Clipboard);
@@ -214,14 +218,15 @@ public partial class App : Application
                 desktop.Startup -= Desktop_Startup;
             }
 
-            _listeningToFiles = Task.Run(ListenToIncomingFiles); // Start listening
+            _listeningToFiles = Task.Run(ListenToIncomingFiles, CancellationToken.None); // Start listening
 
             if (e.Args.Length == 0)
             {
                 return;
             }
 
-            await Task.Run(() => OpenDoc(e.Args[0], CancellationToken.None));
+            // Open current document
+            await Task.Run(() => OpenDoc(e.Args[0], CancellationToken.None), CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/Caly.Core/Controls/DocumentsTabsControl.axaml
+++ b/Caly.Core/Controls/DocumentsTabsControl.axaml
@@ -42,7 +42,7 @@
 						<ToggleButton DockPanel.Dock="Left"
                                       VerticalAlignment="Stretch"
                                       Background="Transparent"
-                                      IsChecked="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).IsDocumentPaneOpen}">
+                                      IsChecked="{Binding AppStates.IsDocumentPaneOpen}">
 							<ToggleButton.Styles>
 								<Style Selector="PathIcon.closed">
 									<Setter Property="Data" Value="{StaticResource pane_close_regular}" />
@@ -54,8 +54,8 @@
 
 							<PathIcon Width="17"
                                       Height="17"
-                                      Classes.opened="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).IsDocumentPaneOpen}"
-									  Classes.closed="{Binding !$parent[UserControl].((vm:MainViewModel)DataContext).IsDocumentPaneOpen}">
+                                      Classes.opened="{Binding AppStates.IsDocumentPaneOpen}"
+									  Classes.closed="{Binding !AppStates.IsDocumentPaneOpen}">
 								<ToolTip.Tip>Toggle Sidebar Menu</ToolTip.Tip>
 							</PathIcon>
 						</ToggleButton>
@@ -199,8 +199,8 @@
 
 					<SplitView Grid.Row="1"
 							   Name="PART_SplitView"
-							   IsPaneOpen="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).IsDocumentPaneOpen, Mode=TwoWay}"
-							   OpenPaneLength="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).PaneSize, Mode=TwoWay}"
+							   IsPaneOpen="{Binding AppStates.IsDocumentPaneOpen, Mode=TwoWay}"
+							   OpenPaneLength="{Binding AppStates.PaneSize, Mode=TwoWay}"
 							   CompactPaneLength="0"
 							   DisplayMode="CompactInline">
 
@@ -213,7 +213,7 @@
 						<SplitView.Pane>
 
 							<Grid ColumnDefinitions="*,5"
-                                  IsVisible="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).IsDocumentPaneOpen}">
+                                  IsVisible="{Binding AppStates.IsDocumentPaneOpen}">
 
                                 <Border Grid.Column="0"
                                         BorderThickness="1">
@@ -238,7 +238,7 @@
 											</TabItem.Header>
 											<Grid>
                                                 <controls:ThumbnailItemsControl
-                                                    IsVisible="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).IsDocumentPaneOpen}"
+                                                    IsVisible="{Binding AppStates.IsDocumentPaneOpen}"
                                                     RefreshThumbnails="{Binding RefreshThumbnailsCommand}"
 													RealisedThumbnails="{Binding RealisedThumbnails}"
 													VisibleThumbnails="{Binding VisibleThumbnails}"

--- a/Caly.Core/Controls/DocumentsTabsControl.axaml.cs
+++ b/Caly.Core/Controls/DocumentsTabsControl.axaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 BobLd
+// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
 
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Metadata;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.VisualTree;
@@ -35,8 +34,6 @@ namespace Caly.Core.Controls;
 /// Control that represents all open PDF documents, together with the top and left navigation panels.
 /// Each PDF document is displayed in a tab.
 /// </summary>
-[TemplatePart("PART_TextBoxPageNumber", typeof(TextBox))]
-[TemplatePart("PART_SplitView", typeof(SplitView))]
 public sealed partial class DocumentsTabsControl : UserControl
 {
     private const int MaxPaneLength = 500;

--- a/Caly.Core/Controls/PageItem.axaml
+++ b/Caly.Core/Controls/PageItem.axaml
@@ -1,10 +1,14 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Caly.Core.Controls"
+                    xmlns:converters="using:Caly.Core.Converters"
                     xmlns:vm="clr-namespace:Caly.Core.ViewModels"
                     xmlns:progRing="clr-namespace:AvaloniaProgressRing;assembly=AvaloniaProgressRing"
                     xmlns:utilities="clr-namespace:Caly.Core.Utilities"
                     xmlns:rendering="clr-namespace:Caly.Core.Controls.Rendering">
+
+    <converters:ProgressRingSizeConverter x:Key="ProgressRingSizeConverter"/>
+    <converters:ProgressRingMarginConverter x:Key="ProgressRingMarginConverter"/>
 
     <Design.PreviewWith>
 		<StackPanel Width="400" Height="400">
@@ -77,13 +81,23 @@
 								  Width="{Binding Size.Width}"
 								  Height="{Binding Size.Height}">
 
-								<Viewbox Width="{Binding ProgressRingSize}"
-										 Height="{Binding ProgressRingSize}"
-										 Margin="{Binding ProgressRingMargin}"
-										 IsVisible="{Binding IsPageRendering}"
+								<Viewbox IsVisible="{Binding IsPageRendering}"
 										 IsEnabled="{Binding IsPageRendering}"
 										 HorizontalAlignment="Left"
 										 VerticalAlignment="Top">
+									<Viewbox.Width>
+										<!-- No Height binding: Viewbox stretches uniformly, so Height follows Width-->
+                                        <MultiBinding Converter="{StaticResource ProgressRingSizeConverter}">
+											<Binding Path="VisibleArea"/>
+											<Binding Path="Size"/>
+										</MultiBinding>
+									</Viewbox.Width>
+									<Viewbox.Margin>
+										<MultiBinding Converter="{StaticResource ProgressRingMarginConverter}">
+											<Binding Path="VisibleArea"/>
+											<Binding Path="Size"/>
+										</MultiBinding>
+									</Viewbox.Margin>
 									<progRing:ProgressRing Width="50"
 														   Height="50"
 														   IsActive="{Binding IsPageRendering}"

--- a/Caly.Core/Converters/ProgressRingPlacementConverters.cs
+++ b/Caly.Core/Converters/ProgressRingPlacementConverters.cs
@@ -1,0 +1,73 @@
+// Copyright (c) BobLd
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace Caly.Core.Converters;
+
+/// <summary>
+/// Positions the page-loading progress ring within the visible area of the page.
+/// Inputs for both converters are the page's visible area (<see cref="Rect"/>?, may be
+/// <c>null</c> when the whole page is used) and the page size (<see cref="Size"/>).
+/// </summary>
+internal static class ProgressRingPlacement
+{
+    internal static Rect GetArea(IList<object?> values)
+    {
+        Rect? visibleArea = values.Count > 0 && values[0] is Rect r ? r : null;
+        Size size = values.Count > 1 && values[1] is Size s ? s : default;
+        return visibleArea ?? new Rect(default, size);
+    }
+
+    /// <summary>
+    /// Diameter of the loading progress ring, scaled to the area.
+    /// </summary>
+    internal static double GetSize(Rect area)
+    {
+        double size = 0.10 * Math.Min(area.Width, area.Height);
+        return size < 5 ? 5 : size;
+    }
+}
+
+public sealed class ProgressRingSizeConverter : IMultiValueConverter
+{
+    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return ProgressRingPlacement.GetSize(ProgressRingPlacement.GetArea(values));
+    }
+}
+
+/// <summary>
+/// Margin that positions the loading progress ring at the center of the area.
+/// </summary>
+public sealed class ProgressRingMarginConverter : IMultiValueConverter
+{
+    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        Rect area = ProgressRingPlacement.GetArea(values);
+        Point center = area.Center;
+        double half = ProgressRingPlacement.GetSize(area) / 2.0;
+        return new Thickness(center.X - half, center.Y - half, 0, 0);
+    }
+}

--- a/Caly.Core/Services/JsonSettingsService.cs
+++ b/Caly.Core/Services/JsonSettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -176,7 +176,7 @@ internal sealed class JsonSettingsService : ISettingsService
 
             if (mw.DataContext is MainViewModel vm)
             {
-                vm.PaneSize = _current.PaneSize;
+                vm.AppStates.PaneSize = _current.PaneSize;
             }
 
             // Set window size and location

--- a/Caly.Core/ViewModels/ApplicationStates.cs
+++ b/Caly.Core/ViewModels/ApplicationStates.cs
@@ -1,0 +1,54 @@
+// Copyright (c) BobLd
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Caly.Core.Models;
+using Caly.Core.Services.Interfaces;
+using Caly.Core.Utilities;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Caly.Core.ViewModels;
+
+/// <summary>
+/// App-level states, shared across all documents. A single instance is
+/// created at startup, handed to <see cref="MainViewModel"/> and registered in DI so
+/// each <see cref="DocumentViewModel"/> receives the same one; views bind to it
+/// through their own DataContext instead of casting an ancestor's.
+/// </summary>
+public sealed partial class ApplicationStates : ObservableObject
+{
+    /// <summary>
+    /// Whether the document side pane is open.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsDocumentPaneOpen { get; set; } = !CalyExtensions.IsMobilePlatform();
+
+    /// <summary>
+    /// Width of the document side pane, persisted to settings.
+    /// </summary>
+    [ObservableProperty]
+    public partial double PaneSize { get; set; }
+
+    partial void OnPaneSizeChanged(double oldValue, double newValue)
+    {
+        App.Current?.Services?.GetService<ISettingsService>()?
+            .SetProperty(CalySettings.CalySettingsProperty.PaneSize, newValue);
+    }
+}

--- a/Caly.Core/ViewModels/DocumentViewModel.cs
+++ b/Caly.Core/ViewModels/DocumentViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -62,6 +62,12 @@ public sealed partial class DocumentViewModel : ViewModelBase
     internal string? LocalPath { get; private set; }
 
     public bool IsActive => _pdfService.IsActive;
+
+    /// <summary>
+    /// App-level states, shared across all documents. Exposed
+    /// here so views inside the document's template can bind to it directly.
+    /// </summary>
+    public ApplicationStates AppStates { get; }
 
     [ObservableProperty] private ObservableCollection<PageViewModel> _pages = [];
 
@@ -174,6 +180,7 @@ public sealed partial class DocumentViewModel : ViewModelBase
         _bookmarksTask = null!;
         _buildSearchIndex = null!;
         _searchResultsSource = null!;
+        AppStates = new ApplicationStates();
 
         _pdfService = new PdfPigDocumentService(new JsonSettingsService(null!));
 
@@ -185,9 +192,12 @@ public sealed partial class DocumentViewModel : ViewModelBase
     }
 #endif
 
-    public DocumentViewModel(IPdfDocumentService pdfService, PdfPageService pdfPageService, ITextSearchService textSearchService)
+    public DocumentViewModel(IPdfDocumentService pdfService, PdfPageService pdfPageService,
+        ITextSearchService textSearchService, ApplicationStates appStates)
     {
         ArgumentNullException.ThrowIfNull(pdfService, nameof(pdfService));
+        ArgumentNullException.ThrowIfNull(appStates, nameof(appStates));
+        AppStates = appStates;
 
         System.Diagnostics.Debug.Assert(pdfService.NumberOfPages == 0);
 

--- a/Caly.Core/ViewModels/MainViewModel.cs
+++ b/Caly.Core/ViewModels/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,6 @@
 // SOFTWARE.
 
 using Avalonia.Collections;
-using Caly.Core.Models;
 using Caly.Core.Services;
 using Caly.Core.Services.Interfaces;
 using Caly.Core.Utilities;
@@ -53,17 +52,9 @@ public sealed partial class MainViewModel : ViewModelBase, IDisposable
     [ObservableProperty] private bool _isSettingsPaneOpen;
 
     /// <summary>
-    /// Whether the document side pane is open. App-level value shared across all documents:
-    /// closing the pane on one document keeps it closed for every document.
+    /// App-level states, shared across all documents.
     /// </summary>
-    [ObservableProperty]
-    public partial bool IsDocumentPaneOpen { get; set; } = !CalyExtensions.IsMobilePlatform();
-
-    /// <summary>
-    /// Width of the document side pane. App-level value (shared across all documents) persisted to settings.
-    /// </summary>
-    [ObservableProperty]
-    public partial double PaneSize { get; set; }
+    public ApplicationStates AppStates { get; }
 
     public DocumentViewModel? SelectedDocument
     {
@@ -120,20 +111,25 @@ public sealed partial class MainViewModel : ViewModelBase, IDisposable
             _lastAnnouncedSelectedDocument = selected;
             if (selected is not null)
             {
-                App.Messenger.Send(new SelectedDocumentChangedMessage(selected));
+                Core.App.Messenger.Send(new SelectedDocumentChangedMessage(selected));
             }
         });
     }
 
-
-    partial void OnPaneSizeChanged(double oldValue, double newValue)
+#if DEBUG
+    /// <summary>
+    /// Design-time constructor.
+    /// </summary>
+    public MainViewModel() : this(new ApplicationStates())
     {
-        App.Current?.Services?.GetService<ISettingsService>()?
-            .SetProperty(CalySettings.CalySettingsProperty.PaneSize, newValue);
     }
+#endif
 
-    public MainViewModel()
+    public MainViewModel(ApplicationStates appStates)
     {
+        ArgumentNullException.ThrowIfNull(appStates, nameof(appStates));
+        AppStates = appStates;
+
         // Documents are added/removed on the UI thread; the selected document can
         // change on collection changes without SelectedDocumentIndex changing.
         PdfDocuments.CollectionChanged += (_, _) => ScheduleSelectedDocumentChanged();
@@ -222,7 +218,6 @@ public sealed partial class MainViewModel : ViewModelBase, IDisposable
     [RelayCommand]
     private async Task CloseTab(object tabItem, CancellationToken token)
     {
-        // TODO - Finish proper dispose / unload of document on close 
         if (((DragTabItem)tabItem)?.DataContext is DocumentViewModel vm)
         {
             await CloseDocumentInternal(vm, token);
@@ -262,7 +257,7 @@ public sealed partial class MainViewModel : ViewModelBase, IDisposable
     [RelayCommand]
     private void ActivateSearchTextTab()
     {
-        IsDocumentPaneOpen = true;
+        AppStates.IsDocumentPaneOpen = true;
         SelectedDocument?.SelectedTabIndex = 2;
     }
 

--- a/Caly.Core/ViewModels/PageViewModel.cs
+++ b/Caly.Core/ViewModels/PageViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 BobLd
+﻿// Copyright (c) BobLd
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -61,8 +61,6 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
     [NotifyPropertyChangedFor(nameof(ThumbnailSize))]
     [NotifyPropertyChangedFor(nameof(DisplayWidth))]
     [NotifyPropertyChangedFor(nameof(DisplayHeight))]
-    [NotifyPropertyChangedFor(nameof(ProgressRingSize))]
-    [NotifyPropertyChangedFor(nameof(ProgressRingMargin))]
     private Size _size;
 
     [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsThumbnailRendering))]
@@ -74,8 +72,6 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsPageVisible))]
-    [NotifyPropertyChangedFor(nameof(ProgressRingSize))]
-    [NotifyPropertyChangedFor(nameof(ProgressRingMargin))]
     private Rect? _visibleArea;
 
     [ObservableProperty]
@@ -105,32 +101,6 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
     public double DisplayWidth => IsPortrait ? Size.Width : Size.Height;
 
     public double DisplayHeight => IsPortrait ? Size.Height : Size.Width;
-
-    /// <summary>
-    /// Diameter of the loading progress ring, scaled to the visible area of the page.
-    /// </summary>
-    public double ProgressRingSize
-    {
-        get
-        {
-            Rect area = VisibleArea ?? new Rect(default, Size);
-            double size = 0.10 * Math.Min(area.Width, area.Height);
-            return size < 5 ? 5 : size;
-        }
-    }
-
-    /// <summary>
-    /// Margin that positions the loading progress ring at the center of the visible area of the page.
-    /// </summary>
-    public Thickness ProgressRingMargin
-    {
-        get
-        {
-            Point center = (VisibleArea ?? new Rect(default, Size)).Center;
-            double half = ProgressRingSize / 2.0;
-            return new Thickness(center.X - half, center.Y - half, 0, 0);
-        }
-    }
 
     public bool IsThumbnailRendering => Thumbnail is null;
 
@@ -220,12 +190,27 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
         TextSelection.TextSelectionReset += _onTextSelectionReset;
     }
 
+    /// <summary>
+    /// Assigns <see cref="SelectedWords"/> on the UI thread without blocking the
+    /// caller. Always posted (never inline) so UI-thread and background callers are
+    /// serialized in FIFO order; the generated setter ignores no-op assignments.
+    /// </summary>
+    private void SetSelectedWords(IReadOnlyList<PdfRectangle>? value)
+    {
+        Dispatcher.UIThread.Post(() => SelectedWords = value);
+    }
+
+    /// <summary>
+    /// Same dispatch strategy as <see cref="SetSelectedWords"/>, for <see cref="SearchResults"/>.
+    /// </summary>
+    private void SetSearchResults(IReadOnlyList<PdfRectangle>? value)
+    {
+        Dispatcher.UIThread.Post(() => SearchResults = value);
+    }
+
     private void _onTextSelectionReset(object? sender, EventArgs e)
     {
-        if (SelectedWords is not null)
-        {
-            Dispatcher.UIThread.Invoke(() => SelectedWords = null);
-        }
+        SetSelectedWords(null);
     }
 
     private void _onTextSelectionFocusPageChanged(object? sender, TextSelectionFocusPageChangedEventArgs e)
@@ -270,12 +255,12 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
     {
         if (_searchResultsRanges is null || _searchResultsRanges.Count == 0)
         {
-            Dispatcher.UIThread.Invoke(() => SearchResults = null);
+            SetSearchResults(null);
             return;
         }
 
         System.Diagnostics.Debug.Assert(PdfTextLayer is not null);
-        
+
         var results = new List<PdfRectangle>(_searchResultsRanges.Count);
         foreach (var range in _searchResultsRanges)
         {
@@ -285,27 +270,16 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
                 .Select(x => x.BoundingBox));
         }
 
-        if (results.Count > 0)
-        {
-            Dispatcher.UIThread.Invoke(() => SearchResults = results);
-        }
-        else
-        {
-            Dispatcher.UIThread.Invoke(() => SearchResults = null);
-        }
+        SetSearchResults(results.Count > 0 ? results : null);
     }
 
     private void RefreshTextSelection()
     {
         System.Diagnostics.Debug.Assert(PdfTextLayer is not null);
-        
+
         if (!TextSelection.IsPageInSelection(PageNumber))
         {
-            if (SelectedWords is not null)
-            {
-                Dispatcher.UIThread.Invoke(() => SelectedWords = null);
-            }
-
+            SetSelectedWords(null);
             return;
         }
 
@@ -313,10 +287,7 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
 
         if (selectedWords.Length == 0)
         {
-            if (SelectedWords is not null)
-            {
-                Dispatcher.UIThread.Invoke(() => SelectedWords = null);  // TODO - Check if we should do that here
-            }
+            SetSelectedWords(null);  // TODO - Check if we should do that here
         }
         else
         {
@@ -324,7 +295,7 @@ public sealed partial class PageViewModel : ViewModelBase, IDisposable
                     selectedWords, PageNumber,
                     PdfWordHelpers.GetRectangle, PdfWordHelpers.GetRectangle)
                 .ToArray();
-            Dispatcher.UIThread.Invoke(() => SelectedWords = selectedWordRects);
+            SetSelectedWords(selectedWordRects);
         }
     }
 

--- a/Caly.Tests/ProgressRingPlacementConvertersTests.cs
+++ b/Caly.Tests/ProgressRingPlacementConvertersTests.cs
@@ -1,0 +1,53 @@
+using Avalonia;
+using Caly.Core.Converters;
+
+namespace Caly.Tests;
+
+public class ProgressRingPlacementConvertersTests
+{
+    private static readonly ProgressRingSizeConverter SizeConverter = new();
+    private static readonly ProgressRingMarginConverter MarginConverter = new();
+
+    [Fact]
+    public void Size_IsTenPercentOfSmallestVisibleAreaDimension()
+    {
+        object result = SizeConverter.Convert([new Rect(10, 20, 300, 400), new Size(1000, 1000)], typeof(double), null, null!);
+
+        Assert.Equal(30d, Assert.IsType<double>(result));
+    }
+
+    [Fact]
+    public void Size_IsClampedToMinimumOfFive()
+    {
+        object result = SizeConverter.Convert([new Rect(0, 0, 30, 40), new Size(1000, 1000)], typeof(double), null, null!);
+
+        Assert.Equal(5d, Assert.IsType<double>(result));
+    }
+
+    [Fact]
+    public void Size_FallsBackToPageSize_WhenVisibleAreaIsNull()
+    {
+        object result = SizeConverter.Convert([null, new Size(200, 100)], typeof(double), null, null!);
+
+        Assert.Equal(10d, Assert.IsType<double>(result));
+    }
+
+    [Fact]
+    public void Margin_CentersRingInVisibleArea()
+    {
+        // Area centre is (160, 220); ring diameter is 30, so the top-left corner is offset by 15.
+        object result = MarginConverter.Convert([new Rect(10, 20, 300, 400), new Size(1000, 1000)], typeof(Thickness), null, null!);
+
+        Assert.Equal(new Thickness(145, 205, 0, 0), Assert.IsType<Thickness>(result));
+    }
+
+    [Fact]
+    public void Converters_TolerateUnsetValues()
+    {
+        object size = SizeConverter.Convert([AvaloniaProperty.UnsetValue, AvaloniaProperty.UnsetValue], typeof(double), null, null!);
+        object margin = MarginConverter.Convert([AvaloniaProperty.UnsetValue, AvaloniaProperty.UnsetValue], typeof(Thickness), null, null!);
+
+        Assert.Equal(5d, Assert.IsType<double>(size));
+        Assert.IsType<Thickness>(margin);
+    }
+}


### PR DESCRIPTION
- Introduce a shared ApplicationStates injected into MainViewModel and every DocumentViewModel, replacing the MainViewModel ancestor-cast bindings in DocumentsTabsControl.
- Replace blocking Dispatcher.Invoke with Post in PageViewModel.
- Move the progress-ring placement math from the view model into converters with unit tests.
- Drop the meaningless TemplatePart attributes on DocumentsTabsControl.